### PR TITLE
Helm bugfix

### DIFF
--- a/helm/kuberhealthy/templates/deployment.yaml
+++ b/helm/kuberhealthy/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
             memory: {{ .Values.resources.requests.memory }}
       restartPolicy: Always
       terminationGracePeriodSeconds: 310
-{{- if .Values.tolerations.master -}}
+{{- if .Values.tolerations.master }}
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master


### PR DESCRIPTION
Fixes an issue with the master toleration, where the `-}}` removes a needed newline.

Before fix:
```
   terminationGracePeriodSeconds: 310tolerations:
   - effect: NoSchedule
      key: node-role.kubernetes.io/master
```

After:

```
   terminationGracePeriodSeconds: 310
   tolerations:
   - effect: NoSchedule
      key: node-role.kubernetes.io/master
```
