### PR TITLE
fixing prometheus rules integration for operator and additionalLabels

### DIFF
--- a/.ci/values.yaml
+++ b/.ci/values.yaml
@@ -9,13 +9,15 @@ checkReaper:
 prometheus:
   enabled: false
   name: "prometheus"
-  release: prometheus-operator
   serviceMonitor:
     enabled: false
+    release: prometheus-operator
     endpoints:
       interval: 15s
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-  enableAlerting: false
+  prometheusRule:
+    enabled: false
+    release: prometheus-operator
 
 image:
   registry: kuberhealthy

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -49,17 +49,17 @@ A helm chart for deploying Kuberhealthy.  This is the same helm chart published 
   `helm install kuberhealthy kuberhealthy/kuberhealthy`
 
   - With Prometheus:
-  `helm install kuberhealthy kuberhealthy/kuberhealthy --set prometheus.enabled=true  --set prometheus.enableAlerting=true`
+  `helm install kuberhealthy kuberhealthy/kuberhealthy --set prometheus.enabled=true  --set prometheus.prometheusRule.enabled=true`
 
   - With Prometheus Operator:
-  `helm install kuberhealthy kuberhealthy/kuberhealthy --set prometheus.enabled=true  --set prometheus.enableAlerting=true --set prometheus.serviceMonitor.enabled=true --set prometheus.serviceMonitor.release={prometheus-operator-release-name} --set prometheus.serviceMonitor.namespace={prometheus-operator-namespace}` 
+  `helm install kuberhealthy kuberhealthy/kuberhealthy --set prometheus.enabled=true  --set prometheus.prometheusRule.enabled=true --set prometheus.prometheusRule.release={prometheus-operator-release-name} --set prometheus.prometheusRule.namespace={prometheus-operator-namespace} --set prometheus.serviceMonitor.enabled=true --set prometheus.serviceMonitor.release={prometheus-operator-release-name} --set prometheus.serviceMonitor.namespace={prometheus-operator-namespace}` 
 
   - With [kube-prometheus](https://github.com/prometheus-operator/kube-prometheus):
   
-    - Make sure to set your serviceMonitor `release:` label with the matching serviceMonitorSelector `release:` label in your prometheus configuration. This is set to whatever you name your release when you helm install the kube-prometheus-stack. Ex. `helm install prometheus prometheus-community/kube-prometheus-stack` implies that your release name is `prometheus` and so your serviceMonitor should be set with the label `release: prometheus`.
-    - Make sure you set your serviceMonitor namespace to wherever you've deployed your kube-prometheus-stack
+    - Make sure to set your serviceMonitor and prometheusRule `release:` label with the matching serviceMonitorSelector `release:` label in your prometheus configuration. This is set to whatever you name your release when you helm install the kube-prometheus-stack. Ex. `helm install prometheus prometheus-community/kube-prometheus-stack` implies that your release name is `prometheus` and so your serviceMonitor should be set with the label `release: prometheus`.
+    - Make sure you set your serviceMonitor and prometheusRule namespaces to wherever you've deployed your kube-prometheus-stack
   
-    - `helm install kuberhealthy kuberhealthy/kuberhealthy --set prometheus.enabled=true  --set prometheus.enableAlerting=true --set prometheus.serviceMonitor.enabled=true --set prometheus.serviceMonitor.release={kube-prometheus-stack-release-name} --set prometheus.serviceMonitor.namespace={kube-prometheus-stack-namespace}`
+    - `helm install kuberhealthy kuberhealthy/kuberhealthy --set prometheus.enabled=true  --set prometheus.prometheusRule.enabled=true --set prometheus.prometheusRule.release={prometheus-operator-release-name} --set prometheus.prometheusRule.namespace={prometheus-operator-namespace} --set prometheus.serviceMonitor.enabled=true --set prometheus.serviceMonitor.release={kube-prometheus-stack-release-name} --set prometheus.serviceMonitor.namespace={kube-prometheus-stack-namespace}`
 
 
 ### Helm

--- a/deploy/helm/create-flat-files.sh
+++ b/deploy/helm/create-flat-files.sh
@@ -11,10 +11,10 @@ echo "Creating flat kuberhealthy.yaml"
 $HELM template --namespace kuberhealthy kuberhealthy > ../kuberhealthy.yaml
 
 echo "Creating flat kuberhealthy-prometheus.yaml"
-$HELM template --namespace kuberhealthy kuberhealthy kuberhealthy --set prometheus.enabled=true  --set prometheus.enableAlerting=true > ../kuberhealthy-prometheus.yaml
+$HELM template --namespace kuberhealthy kuberhealthy kuberhealthy --set prometheus.enabled=true  --set prometheus.prometheusRule.enabled=true > ../kuberhealthy-prometheus.yaml
 
 echo "Creating flat kuberhealthy-prometheus-operator.yaml"
-$HELM template --namespace kuberhealthy kuberhealthy kuberhealthy --set prometheus.enabled=true  --set prometheus.enableAlerting=true --set prometheus.serviceMonitor.enabled=true > ../kuberhealthy-prometheus-operator.yaml
+$HELM template --namespace kuberhealthy kuberhealthy kuberhealthy --set prometheus.enabled=true  --set prometheus.prometheusRule.enabled=true --set prometheus.serviceMonitor.enabled=true > ../kuberhealthy-prometheus-operator.yaml
 
 
 # temp helm fix described in issue #279:

--- a/deploy/helm/kuberhealthy/NOTES.txt
+++ b/deploy/helm/kuberhealthy/NOTES.txt
@@ -8,7 +8,8 @@ Kuberhealthy has been installed to your cluster!
 	Tolerates Masters: {{ .Values.tolerations.master }}
 {{- if .Values.prometheus.enabled -}}
 	Prometheus Enabled: {{ .Values.prometheus.enabled }}
-	Prometheus Alerting: {{ .Values.prometheus.enableAlerting }}
+	Prometheus ServiceMonitor created: {{ .Values.prometheus.serviceMonitor.enabled }}
+	Prometheus Rule created: {{ .Values.prometheus.prometheusRule.enabled }}
 {{- end -}}
 
 If you are using Prometheus alert manager for your alerts, Kuberhealthy should

--- a/deploy/helm/kuberhealthy/README.md
+++ b/deploy/helm/kuberhealthy/README.md
@@ -28,14 +28,21 @@ It is possible to configure Kuberhealthy's Prometheus integration with Helm vari
 
 ```
 prometheus:
-  enabled: true # do we deploy a ServiceMonitor spec?
+  enabled: true # do we deploy a ServiceMonitor or PrometheusRule spec?
   name: "prometheus" # the name of the Prometheus deployment in your environment.
   serviceMonitor:
-    enabled: false # use a ServiceMonitor configuration, for if using Prometheus Operator
+    enabled: false # create a ServiceMonitor resource, when using Prometheus Operator (f.e. kube-prometheus-stack)
+    release: prometheus-stack
+    additionalLabels:
+      env: "dev"
     endpoints: # Endpoint specification
       interval: 15s
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-  enableAlerting: true # enable default Kuberhealthy alerts configuration
+  prometheusRule:
+    enabled: true # create a PrometheusRule resource, when using Prometheus Operator (f.e. kube-prometheus-stack)
+    release: prometheus-stack
+    additionalLabels:
+      env: "dev"
 app:
   name: "kuberhealthy" # what to name the kuberhealthy deployment
 image:

--- a/deploy/helm/kuberhealthy/templates/prometheusrule.yml
+++ b/deploy/helm/kuberhealthy/templates/prometheusrule.yml
@@ -1,14 +1,21 @@
 {{- if .Values.prometheus.enabled }}
-{{- if .Values.prometheus.enableAlerting }}
+{{- /*
+  Also check for .Values.prometheus.enableAlerting to support backwards compatibility since version 69+
+*/}}
+{{- if or .Values.prometheus.prometheusRule.enabled .Values.prometheus.enableAlerting }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
     prometheus: {{ .Values.prometheus.name }}
+    release: {{ .Values.prometheus.prometheusRule.release }}
     role: alert-rules
+    {{- if .Values.prometheus.prometheusRule.additionalLabels }}
+    {{- toYaml .Values.prometheus.prometheusRule.additionalLabels | nindent 4 }}
+    {{- end }}
   name: {{ template "kuberhealthy.name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.prometheus.prometheusRule.namespace }}
 spec:
   groups:
     - name: ./kuberhealthy.rules

--- a/deploy/helm/kuberhealthy/templates/servicemonitor.yaml
+++ b/deploy/helm/kuberhealthy/templates/servicemonitor.yaml
@@ -9,7 +9,7 @@ metadata:
     prometheus: {{ .Values.prometheus.name }}
     release: {{ .Values.prometheus.serviceMonitor.release }}
     {{- if .Values.prometheus.serviceMonitor.additionalLabels}}
-    additionalLabels: {{ .Values.prometheus.serviceMonitor.additionalLabels | nindent 6}}
+    {{- toYaml .Values.prometheus.serviceMonitor.additionalLabels | nindent 4 }}
     {{- end }}
   name: {{ template "kuberhealthy.name" . }}
   namespace: {{ .Values.prometheus.serviceMonitor.namespace }}

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -16,14 +16,20 @@ prometheus:
     enabled: false
     release: prometheus-operator
     additionalLabels: {}
-    #- env: "dev"
-    #  app: "appName"
+      # env: "dev"
+      # mycustomlabel: "value"
     endpoints:
       interval: 15s
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     namespace: kuberhealthy # prometheus operator must be allowed to scrape serviceMonitor metrics from kuberhealthy namespace or set to namespace of prometheus operator
 
-  enableAlerting: false
+  prometheusRule:
+    enabled: false
+    release: prometheus-operator
+    additionalLabels: {}
+      # env: "dev"
+      # mycustomlabel: "value"
+    namespace: kuberhealthy
 
 # imageRegistry can be used to globally override where check images are pulled from. Individual checks can be overridden below.
 # By default if no overrides are specified, all images are pulled from Docker Hub.  Do not include a trailing '/'.

--- a/docs/K8s-KPIs-with-Kuberhealthy.md
+++ b/docs/K8s-KPIs-with-Kuberhealthy.md
@@ -22,12 +22,12 @@ in this [deploy folder](https://github.com/kuberhealthy/kuberhealthy/tree/master
 
   - If you use the [Prometheus Operator](https://github.com/coreos/prometheus-operator):
   ```
-  helm install kuberhealthy kuberhealthy/kuberhealthy --set prometheus.enabled=true,prometheus.enableAlerting=true,prometheus.serviceMonitor.enabled=true
+  helm install kuberhealthy kuberhealthy/kuberhealthy --set prometheus.enabled=true,prometheus.prometheusRule.enabled=true,prometheus.serviceMonitor.enabled=true
   ```
 
   - If you use Prometheus, but NOT Prometheus Operator:
   ```
-  helm install kuberhealthy kuberhealthy/kuberhealthy --set prometheus.enabled=true,prometheus.enableAlerting=true
+  helm install kuberhealthy kuberhealthy/kuberhealthy --set prometheus.enabled=true,prometheus.prometheusRule.enabled=true
   ```
    See additional details about configuring the appropriate scrape annotations in the section [Prometheus Integration Details](#prometheus-integration-details) below.
 


### PR DESCRIPTION
Hi there,

this PR addresses multiple problems I was facing during evaluation deployment:

- the `PrometheusRule` custom resource was not recognized and automatically loaded from the Prometheus Operator (`kube-prometheus-stack`), because the `release` label is missing
- I was unable to use `additionalLabels` on that custom resource, because it was only implemented for the `ServiceMonitor` custom resource
- Trying to use `additionalLabels` on the `ServiceMonitor` custom resource did not work - there seems to be some type mixtures and implementation issues in the helm template

The fixes include:
- renaming `prometheus.enableAlerting` to `prometheus.prometheusRule` to more accurately represent the custom resource we deploy (file `templates/prometheusrule.yml` with `kind: PrometheusRule`)
- keep validating against `.Values.prometheus.enableAlerting` for backwards compatibility
- add additional configuration options to `prometheus.prometheusRule` (more or less same as used in `prometheus.serviceMonitor`)
- fixing usage of `prometheus.serviceMonitor.additionalLabels`
- updating all documentation I could find about these settings
- also updating scripts and CI files

I am unsure about the versioning you use for `Chart.yaml` (and if maybe you generate it from some CI pipeline?), so I did not yet bump the chart version. Give me a hint if I should do this manually.