### PR TITLE
Add missing namespace metadata to helm chart configmap

### DIFF
--- a/deploy/helm/kuberhealthy/templates/configmap.yaml
+++ b/deploy/helm/kuberhealthy/templates/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kuberhealthy
+  namespace: {{ .Release.Namespace }}
 data:
   kuberhealthy.yaml: |-
     listenAddress: ":8080" # The port for kuberhealthy to listen on for web requests


### PR DESCRIPTION
This should fix #976... 