### PR TITLE
policy/v1beta1 downgrade from policy/v1 for PDB

### DIFF
--- a/deploy/helm/kuberhealthy/templates/poddisruptionbudget.yaml
+++ b/deploy/helm/kuberhealthy/templates/poddisruptionbudget.yaml
@@ -1,6 +1,6 @@
 ---
 {{- if .Values.podDisruptionBudget.enabled }}
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name:  {{ template "kuberhealthy.name" . }}-pdb


### PR DESCRIPTION
This should fix #1000 - `policy/v1beta1` will have support end in Kubernetes 1.25.  Moving to `policy/v1` will cause versions before 1.20 to stop working.