### PR TITLE
Moving determine KHWorkload call to cache layer

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,3 +20,4 @@
 - [Shilla Saebi](https://twitter.com/ShillaSaebi)
 - [Yashvardhan Kukreja](https://twitter.com/yashkukreja98)
 - [Zachary Hanson](mailto:Zachary_Hanson@comcast.com)
+- [Rudrakh Panigrahi](mailto:rudrakhp@gmail.com)

--- a/cmd/kuberhealthy/reflector.go
+++ b/cmd/kuberhealthy/reflector.go
@@ -122,6 +122,9 @@ func (sr *StateReflector) CurrentStatus() health.State {
 			log.Debugln("Current time: ", currentTime)
 		}
 
+		// Possible incorrect KHWorkload type from cache.
+		// Scenario: A KHCheck is deleted and a KHJob is created in the same namespace with the same name, within the cache expiration time period.
+		// Cache has stale data with incorrect KHWorkload type. True vice versa.
 		khWorkload := sr.khWorkloadCache[khState.GetNamespace()+"/"+khState.GetName()].value
 		switch khWorkload {
 		case khstatev1.KHCheck:

--- a/cmd/kuberhealthy/reflector.go
+++ b/cmd/kuberhealthy/reflector.go
@@ -10,9 +10,9 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	khstatev1 "github.com/kuberhealthy/kuberhealthy/v2/pkg/apis/khstate/v1"
 	"github.com/kuberhealthy/kuberhealthy/v2/pkg/health"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // Struct to define cache entry for a KHWorkload
@@ -114,8 +114,8 @@ func (sr *StateReflector) CurrentStatus() health.State {
 
 		// Call determineKHWorkload if cache entry not present
 		if !isPresent {
-			// Determine KHWorkload and set in cache with expiration of 5 mins from currentTime
-			sr.khWorkloadCache[khState.GetNamespace()+"/"+khState.GetName()] = KHWorkloadCacheEntry{determineKHWorkload(khState.Name, khState.Namespace), currentTime.Add(time.Minute * time.Duration(5))}
+			// Determine KHWorkload and set in cache with expiration of 5 mins from now
+			sr.khWorkloadCache[khState.GetNamespace()+"/"+khState.GetName()] = KHWorkloadCacheEntry{determineKHWorkload(khState.Name, khState.Namespace), time.Now().Add(time.Minute * time.Duration(5))}
 		} else { // Debugging purposes
 			log.Debugln("KHWorkload value used from cache for ", khState.GetNamespace()+"/"+khState.GetName())
 			log.Debugln("Cache expiring at: ", khWorkloadCacheEntry.expireAt)

--- a/cmd/kuberhealthy/reflector.go
+++ b/cmd/kuberhealthy/reflector.go
@@ -10,9 +10,9 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	khstatev1 "github.com/kuberhealthy/kuberhealthy/v2/pkg/apis/khstate/v1"
 	"github.com/kuberhealthy/kuberhealthy/v2/pkg/health"
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // Struct to define cache entry for a KHWorkload


### PR DESCRIPTION
Added a map based implementation for an in memory cache to store KHWorkload type (KHCheck or KHJob).

**Why caching?**
Every `/metrics` call triggers a set of `determineKHWorkload()` calls that are K8s API calls under the hood. This adds to the latency of the `/metrics` call, leading to timeout of the Prometheus call for > 25 KHChecks running in a single cluster (with default timeout for prom calls set to 10s).

Adding a cache layer reduces frequency of these calls, thereby reducing the average latency of each `/metrics` call. Providing basic bench-marking for the `/metrics` API on 20 checks running in a single cluster:

* Current implementation:
```bash
 ~/Documents/workspace --------------------------------------------------------------------------------
> curl -w "@curl-format.txt" -o /dev/null -s -X GET http://192.168.49.2:30596/metrics
time_namelookup:  0.000060s
        time_connect:  0.000355s
     time_appconnect:  0.000000s
    time_pretransfer:  0.000459s
       time_redirect:  0.000000s
  time_starttransfer:  7.315992s
                     ----------
          time_total:  7.316137s

 ~/Documents/workspace ----------------------------------------------------------------------------------- 
> curl -w "@curl-format.txt" -o /dev/null -s -X GET http://192.168.49.2:30596/metrics
time_namelookup:  0.000067s
        time_connect:  0.000358s
     time_appconnect:  0.000000s
    time_pretransfer:  0.000456s
       time_redirect:  0.000000s
  time_starttransfer:  5.570377s
                     ----------
          time_total:  5.570425s

 ~/Documents/workspace ----------------------------------------------------------------------------------
> curl -w "@curl-format.txt" -o /dev/null -s -X GET http://192.168.49.2:30596/metrics
time_namelookup:  0.000016s
        time_connect:  0.000129s
     time_appconnect:  0.000000s
    time_pretransfer:  0.000161s
       time_redirect:  0.000000s
  time_starttransfer:  2.609580s
                     ----------
          time_total:  2.609620s
```
* After caching with expiry set to 5 mins:
```bash
 ~/Documents/workspace ----------------------------------------------------------------------
> curl -w "@curl-format.txt" -o /dev/null -s -X GET http://192.168.49.2:31905/metrics
time_namelookup:  0.000064s
        time_connect:  0.000418s
     time_appconnect:  0.000000s
    time_pretransfer:  0.000544s
       time_redirect:  0.000000s
  time_starttransfer:  0.037606s
                     ----------
          time_total:  0.037720s

 ~/Documents/workspace -------------------------------------------------------------------- 
> curl -w "@curl-format.txt" -o /dev/null -s -X GET http://192.168.49.2:31905/metrics
time_namelookup:  0.000065s
        time_connect:  0.000372s
     time_appconnect:  0.000000s
    time_pretransfer:  0.000506s
       time_redirect:  0.000000s
  time_starttransfer:  0.024488s
                     ----------
          time_total:  0.024597s

 ~/Documents/workspace --------------------------------------------------------------------
> curl -w "@curl-format.txt" -o /dev/null -s -X GET http://192.168.49.2:31905/metrics
time_namelookup:  0.000058s
        time_connect:  0.000453s
     time_appconnect:  0.000000s
    time_pretransfer:  0.000558s
       time_redirect:  0.000000s
  time_starttransfer:  0.022601s
                     ----------
          time_total:  0.022713s
```
* After caching, with 50 checks running in a single cluster:
```bash
~/Documents/workspace ---------------------------------------------------------------------- 
> curl -w "@curl-format.txt" -o /dev/null -s -X GET http://192.168.49.2:31382/metrics
time_namelookup:  0.000018s
        time_connect:  0.000131s
     time_appconnect:  0.000000s
    time_pretransfer:  0.000160s
       time_redirect:  0.000000s
  time_starttransfer:  0.009799s
                     ----------
          time_total:  0.009885s

 ~/Documents/workspace ---------------------------------------------------------------------
> curl -w "@curl-format.txt" -o /dev/null -s -X GET http://192.168.49.2:31382/metrics
time_namelookup:  0.000066s
        time_connect:  0.000357s
     time_appconnect:  0.000000s
    time_pretransfer:  0.000459s
       time_redirect:  0.000000s
  time_starttransfer:  0.022229s
                     ----------
          time_total:  0.022318s

 ~/Documents/workspace ----------------------------------------------------------------------  
> curl -w "@curl-format.txt" -o /dev/null -s -X GET http://192.168.49.2:31382/metrics
time_namelookup:  0.000019s
        time_connect:  0.000154s
     time_appconnect:  0.000000s
    time_pretransfer:  0.000192s
       time_redirect:  0.000000s
  time_starttransfer:  0.007152s
                     ----------
          time_total:  0.007327s
```
Note that without caching, the prometheus metrics call fails in a case where 50 checks are running at a time (timeout set to 10s).

**Other details:**
* A simple map based implementation for the in memory cache. Alternatives explored with similar outcomes:
  * [go-cache](https://github.com/patrickmn/go-cache)
* *Drawback:* In rare case scenarios, where a KHCheck is deleted from the cluster and a KHJob with the same name, in the same namespace, is created within the expiration time period (5 mins), the stale KHWorkload data will be used till the entry expires.