### PR TITLE
Add missing SA for dns internal check

### DIFF
--- a/deploy/helm/kuberhealthy/templates/khcheck-dns-internal.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-dns-internal.yaml
@@ -57,4 +57,37 @@ spec:
     tolerations:
 {{- toYaml .Values.check.dnsInternal.tolerations | nindent 6 }}
     {{- end }}
+    serviceAccountName: dns-internal-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dns-internal-check-rb
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dns-internal-service-role
+subjects:
+  - kind: ServiceAccount
+    name: dns-internal-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dns-internal-service-role
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dns-internal-sa
+  namespace: {{ .Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
Hello,

I get this kind of error with the `dns-status-internal` check:
```
time=" " level=error msg="Error waiting for node to reach minimum age: nodes \"aks-linux1-18020575-vmss0003io\" is forbidden: User \"system:serviceaccount:synthetic:default\" cannot get resource \"nodes\" in API group \"\" at the cluster scope"
```

It seems the `dns-status-internal` check, does a 'get node' query:
See there:
- https://github.com/kuberhealthy/kuberhealthy/blob/master/cmd/dns-resolution-check/main.go#L111
- https://github.com/kuberhealthy/kuberhealthy/blob/12c5a48de9ce1aed5e4b81011e9da7dd750075c4/pkg/checks/external/nodeCheck/main.go#L53

The PR adds the missing Service Account and RBAC for this check
