### PR TITLE
Chart fix to use AppVersion by default, allow override via values.yaml

### DIFF
--- a/deploy/helm/kuberhealthy/templates/deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/deployment.yaml
@@ -69,9 +69,9 @@ spec:
 {{- end }}
       containers:
       {{- if .Values.imageRegistry }}
-      - image: {{ .Values.imageRegistry }}/{{ .Values.image.repository }}:{{ .Chart.AppVersion }}
+      - image: {{ .Values.imageRegistry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion}}
       {{- else if .Values.image.registry }}
-      - image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Chart.AppVersion }}
+      - image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion}}
       {{- end }}
         command: {{ .Values.deployment.command }}
         {{- if .Values.deployment.args }}

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -39,7 +39,8 @@ imageRegistry: {}
 image:
   registry: kuberhealthy
   repository: kuberhealthy
-  tag: v2.4.1
+  # Leave empty to use .Chart.AppVersion
+  tag:
 
 resources:
   requests:


### PR DESCRIPTION
Minor fix to the helm chart:

* Chart `values.yaml` incorrectly had old version `v2.4.1`
* Template ignored image tag in `values.yaml` so previous point didn't have actual effect

Now by default `Chart.AppVersion` is used while allowing to override the tag if needed.