### PR TITLE
Fix helm template indentation for securityContext in storage check

### DIFF
--- a/deploy/helm/kuberhealthy/templates/khcheck-storage.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-storage.yaml
@@ -52,11 +52,11 @@ spec:
           memory: {{ $.Values.check.storage.resources.limits.memory }}
           {{- end }}
         {{- end }}
-        {{- if $.Values.securityContext.enabled }}
-        securityContext:
-          allowPrivilegeEscalation: {{ $.Values.securityContext.allowPrivilegeEscalation }}
-          readOnlyRootFilesystem: {{ $.Values.securityContext.readOnlyRootFilesystem }}
-        {{- end }}
+      {{- if $.Values.securityContext.enabled }}
+      securityContext:
+        allowPrivilegeEscalation: {{ $.Values.securityContext.allowPrivilegeEscalation }}
+        readOnlyRootFilesystem: {{ $.Values.securityContext.readOnlyRootFilesystem }}
+      {{- end }}
     restartPolicy: Never
     serviceAccountName: storage-khcheck
     {{- if $.Values.check.storage.nodeSelector }}


### PR DESCRIPTION
This fixes the issue described in #994 which makes the predefined storage check not work