### PR TITLE
fix extraEnvs in values.yaml

### DIFF
--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -122,7 +122,7 @@ check:
       registry: kuberhealthy
       repository: daemonset-check
       tag: v3.3.0
-    extraEnvs:
+    extraEnvs: {}
     nodeSelector: {}
     tolerations:
     #- key: "key"
@@ -227,7 +227,7 @@ check:
       repository: pod-status-check
       tag: v1.3.0
     allNamespaces: false
-    extraEnvs:
+    extraEnvs: {}
     nodeSelector: {}
     tolerations: []
     #- key: "key"


### PR DESCRIPTION
some 'extraEnvs' don't have a default value, and are missing '{}'. This prevents helm from setting those values with a key/value.