### PR TITLE
docs: fix old links

### DIFF
--- a/docs/PROMETHEUS.md
+++ b/docs/PROMETHEUS.md
@@ -1,10 +1,10 @@
 ### Prometheus Integration
 
-Kuberhealthy serves Prometheus metrics at the `/metrics` endpoint.  If you are using the [helm chart](https://github.com/kuberhealthy/kuberhealthy/tree/prom-endpoint-docs/deploy/helm) to deploy Kuberhealthy, 
+Kuberhealthy serves Prometheus metrics at the `/metrics` endpoint.  If you are using the [helm chart](https://github.com/kuberhealthy/kuberhealthy/tree/master/deploy/helm) to deploy Kuberhealthy, 
  enable Prometheus in the chart options to have scrape configs and annotations generated for you.
 
 ```bash
   helm install kuberhealthy kuberhealthy/kuberhealthy --set prometheus.enabled=true  --set prometheus.prometheusRule.enabled=true
 ```
 
-Alternatively, you can use the static files that are generated from the helm chart auotmatically whenever the chart changes [here](https://github.com/kuberhealthy/kuberhealthy/blob/prom-endpoint-docs/deploy/kuberhealthy-prometheus.yaml).
+Alternatively, you can use the static files that are generated from the helm chart auotmatically whenever the chart changes [here](https://github.com/kuberhealthy/kuberhealthy/blob/master/deploy/kuberhealthy-prometheus.yaml).


### PR DESCRIPTION
Link refers to a branch that no longer exists