### PR TITLE
rebuild latest on all package changes

### DIFF
--- a/.github/workflows/build-latest-docker.yml
+++ b/.github/workflows/build-latest-docker.yml
@@ -7,6 +7,7 @@ on:
     - docker-hub # for testing this build spec
     paths:
       - "cmd/kuberhealthy/**"
+      - "pkg/**"
 env:
     IMAGE_NAME: kuberhealthy/kuberhealthy:unstable
 jobs:


### PR DESCRIPTION
This will enable our 'unstable' build pipeline to fire when changes are made to packages, not just the main Kuberhealthy binary.