### PR TITLE
metrics exporter: fix formatting bug

### DIFF
--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -42,6 +42,7 @@ func GenerateMetrics(state health.State) string {
 			for _, error := range d.Errors {
 				errors += fmt.Sprintf("%s|", error)
 			}
+			errors = strings.TrimSuffix(errors, "|")
 		}
 		errors = strings.ReplaceAll(errors, "\"", "'")
 		metricName := fmt.Sprintf("kuberhealthy_check{check=\"%s\",namespace=\"%s\",status=\"%s\",error=\"%s\"}", c, d.Namespace, checkStatus, errors)


### PR DESCRIPTION
Removes trailing pipe character, which can cause errors for downstream metrics consumers, such as [the veneur metrics parser](https://github.com/stripe/veneur/blob/ed29417822e2ae8f2cc4b8f1bda37ab4e7c75768/samplers/parser.go#L396-L400)