### PR TITLE
fix: fix registry variable default values

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,3 +21,4 @@
 - [Yashvardhan Kukreja](https://twitter.com/yashkukreja98)
 - [Zachary Hanson](mailto:Zachary_Hanson@comcast.com)
 - [Zhicheng Li](https://github.com/Hungrylion2019)
+- [Engin Diri](https://twitter.com/_ediri)

--- a/deploy/helm/kuberhealthy/templates/deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/deployment.yaml
@@ -69,9 +69,9 @@ spec:
 {{- end }}
       containers:
       {{- if .Values.imageRegistry }}
-      - image: {{ .Values.imageRegistry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion}}
+      - image: "{{ .Values.imageRegistry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion}}"
       {{- else if .Values.image.registry }}
-      - image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion}}
+      - image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion}}"
       {{- end }}
         command: {{ .Values.deployment.command }}
         {{- if .Values.deployment.args }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
@@ -30,9 +30,9 @@ spec:
             value: {{ $value | quote }}
 {{- end }}
         {{- if .Values.imageRegistry }}
-        image: {{ .Values.imageRegistry }}/{{ .Values.check.daemonset.image.repository }}:{{ .Values.check.daemonset.image.tag }}
+        image: "{{ .Values.imageRegistry }}/{{ .Values.check.daemonset.image.repository }}:{{ .Values.check.daemonset.image.tag }}"
         {{- else if .Values.check.daemonset.image.registry }}
-        image: {{ .Values.check.daemonset.image.registry }}/{{ .Values.check.daemonset.image.repository }}:{{ .Values.check.daemonset.image.tag }}
+        image: "{{ .Values.check.daemonset.image.registry }}/{{ .Values.check.daemonset.image.repository }}:{{ .Values.check.daemonset.image.tag }}"
         {{- end }}
         imagePullPolicy: IfNotPresent
         name: main

--- a/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
@@ -17,9 +17,9 @@ spec:
     containers:
     - name: deployment
       {{- if .Values.imageRegistry }}
-      image: {{ .Values.imageRegistry }}/{{ .Values.check.deployment.image.repository }}:{{ .Values.check.deployment.image.tag }}
+      image: "{{ .Values.imageRegistry }}/{{ .Values.check.deployment.image.repository }}:{{ .Values.check.deployment.image.tag }}"
       {{- else if .Values.check.deployment.image.registry }}
-      image: {{ .Values.check.deployment.image.registry }}/{{ .Values.check.deployment.image.repository }}:{{ .Values.check.deployment.image.tag }}
+      image: "{{ .Values.check.deployment.image.registry }}/{{ .Values.check.deployment.image.repository }}:{{ .Values.check.deployment.image.tag }}"
       {{- end }}
       imagePullPolicy: IfNotPresent
       env:

--- a/deploy/helm/kuberhealthy/templates/khcheck-dns-external.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-dns-external.yaml
@@ -25,9 +25,9 @@ spec:
             value: {{ $value | quote }}
 {{- end }}
         {{- if .Values.imageRegistry }}
-        image: {{ .Values.imageRegistry }}/{{ .Values.check.dnsExternal.image.repository }}:{{ .Values.check.dnsExternal.image.tag }}
+        image: "{{ .Values.imageRegistry }}/{{ .Values.check.dnsExternal.image.repository }}:{{ .Values.check.dnsExternal.image.tag }}"
         {{- else if .Values.check.dnsExternal.image.registry }}
-        image: {{ .Values.check.dnsExternal.image.registry }}/{{ .Values.check.dnsExternal.image.repository }}:{{ .Values.check.dnsExternal.image.tag }}
+        image: "{{ .Values.check.dnsExternal.image.registry }}/{{ .Values.check.dnsExternal.image.repository }}:{{ .Values.check.dnsExternal.image.tag }}"
         {{- end }}
         imagePullPolicy: IfNotPresent
         name: main

--- a/deploy/helm/kuberhealthy/templates/khcheck-dns-internal.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-dns-internal.yaml
@@ -25,9 +25,9 @@ spec:
             value: {{ $value | quote }}
 {{- end }}
         {{- if .Values.imageRegistry }}
-        image: {{ .Values.imageRegistry }}/{{ .Values.check.dnsInternal.image.repository }}:{{ .Values.check.dnsInternal.image.tag }}
+        image: "{{ .Values.imageRegistry }}/{{ .Values.check.dnsInternal.image.repository }}:{{ .Values.check.dnsInternal.image.tag }}"
         {{- else if .Values.check.dnsInternal.image.registry }}
-        image: {{ .Values.check.dnsInternal.image.registry }}/{{ .Values.check.dnsInternal.image.repository }}:{{ .Values.check.dnsInternal.image.tag }}
+        image: "{{ .Values.check.dnsInternal.image.registry }}/{{ .Values.check.dnsInternal.image.repository }}:{{ .Values.check.dnsInternal.image.tag }}"
         {{- end }}
         imagePullPolicy: IfNotPresent
         name: main

--- a/deploy/helm/kuberhealthy/templates/khcheck-network-connection.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-network-connection.yaml
@@ -12,9 +12,9 @@ spec:
     containers:
     - name: deployment
       {{- if .Values.imageRegistry }}
-      image: {{ .Values.imageRegistry }}/{{ .Values.check.networkConnection.image.repository }}:{{ .Values.check.networkConnection.image.tag }}
+      image: "{{ .Values.imageRegistry }}/{{ .Values.check.networkConnection.image.repository }}:{{ .Values.check.networkConnection.image.tag }}"
       {{- else if .Values.check.networkConnection.image.registry }}
-      image: {{ .Values.check.networkConnection.image.registry }}/{{ .Values.check.networkConnection.image.repository }}:{{ .Values.check.networkConnection.image.tag }}
+      image: "{{ .Values.check.networkConnection.image.registry }}/{{ .Values.check.networkConnection.image.repository }}:{{ .Values.check.networkConnection.image.tag }}"
       {{- end }}
       imagePullPolicy: IfNotPresent
       env:

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-restarts.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-restarts.yaml
@@ -26,9 +26,9 @@ spec:
             value: {{ $value | quote }}
 {{- end }}
         {{- if .Values.imageRegistry }}
-        image: {{ .Values.imageRegistry }}/{{ .Values.check.podRestarts.image.repository }}:{{ .Values.check.podRestarts.image.tag }}
+        image: "{{ .Values.imageRegistry }}/{{ .Values.check.podRestarts.image.repository }}:{{ .Values.check.podRestarts.image.tag }}"
         {{- else if .Values.check.podRestarts.image.registry }}
-        image: {{ .Values.check.podRestarts.image.registry }}/{{ .Values.check.podRestarts.image.repository }}:{{ .Values.check.podRestarts.image.tag }}
+        image: "{{ .Values.check.podRestarts.image.registry }}/{{ .Values.check.podRestarts.image.repository }}:{{ .Values.check.podRestarts.image.tag }}"
         {{- end }}
         imagePullPolicy: IfNotPresent
         name: main

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
@@ -28,9 +28,9 @@ spec:
             value: {{ $value | quote }}
 {{- end }}
         {{- if .Values.imageRegistry }}
-        image: {{ .Values.imageRegistry }}/{{ .Values.check.podStatus.image.repository }}:{{ .Values.check.podStatus.image.tag }}
+        image: "{{ .Values.imageRegistry }}/{{ .Values.check.podStatus.image.repository }}:{{ .Values.check.podStatus.image.tag }}"
         {{- else if .Values.check.podStatus.image.registry }}
-        image: {{ .Values.check.podStatus.image.registry }}/{{ .Values.check.podStatus.image.repository }}:{{ .Values.check.podStatus.image.tag }}
+        image: "{{ .Values.check.podStatus.image.registry }}/{{ .Values.check.podStatus.image.repository }}:{{ .Values.check.podStatus.image.tag }}"
         {{- end }}
         imagePullPolicy: IfNotPresent
         name: main
@@ -52,7 +52,7 @@ spec:
           allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
           readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
         {{- end }}
-    
+
     {{- if .Values.check.podStatus.nodeSelector }}
     nodeSelector:
 {{- toYaml .Values.check.podStatus.nodeSelector | nindent 6 }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-storage.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-storage.yaml
@@ -19,9 +19,9 @@ spec:
     containers:
     - name: main
       {{- if $.Values.imageRegistry }}
-      image: {{ $.Values.imageRegistry }}/{{ $.Values.check.storage.image.repository }}:{{ $.Values.check.storage.image.tag }}
+      image: "{{ $.Values.imageRegistry }}/{{ $.Values.check.storage.image.repository }}:{{ $.Values.check.storage.image.tag }}"
       {{- else if $.Values.check.storage.image.registry }}
-      image: {{ $.Values.check.storage.image.registry }}/{{ $.Values.check.storage.image.repository }}:{{ $.Values.check.storage.image.tag }}
+      image: "{{ $.Values.check.storage.image.registry }}/{{ $.Values.check.storage.image.repository }}:{{ $.Values.check.storage.image.tag }}"
       {{- end }}
       imagePullPolicy: IfNotPresent
       env:

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -34,11 +34,11 @@ prometheus:
 
 # imageRegistry can be used to globally override where check images are pulled from. Individual checks can be overridden below.
 # By default if no overrides are specified, all images are pulled from Docker Hub.  Do not include a trailing '/'.
-imageRegistry: {}
+imageRegistry: ""
 
 image:
-  registry: kuberhealthy
-  repository: kuberhealthy
+  registry: docker.io
+  repository: kuberhealthy/kuberhealthy
   # Leave empty to use .Chart.AppVersion
   tag:
 
@@ -120,8 +120,8 @@ check:
     runInterval: 15m
     timeout: 12m
     image:
-      registry: kuberhealthy
-      repository: daemonset-check
+      registry: docker.io
+      repository: kuberhealthy/daemonset-check
       tag: v3.3.0
     extraEnvs: {}
     nodeSelector: {}
@@ -139,8 +139,8 @@ check:
     runInterval: 10m
     timeout: 15m
     image:
-      registry: kuberhealthy
-      repository: deployment-check
+      registry: docker.io
+      repository: kuberhealthy/deployment-check
       tag: v1.9.0
     extraEnvs:
       CHECK_DEPLOYMENT_REPLICAS: "4"
@@ -163,8 +163,8 @@ check:
     runInterval: 2m
     timeout: 15m
     image:
-      registry: kuberhealthy
-      repository: dns-resolution-check
+      registry: docker.io
+      repository: kuberhealthy/dns-resolution-check
       tag: v1.5.0
     extraEnvs:
       HOSTNAME: "kubernetes.default"
@@ -183,8 +183,8 @@ check:
     runInterval: 2m
     timeout: 15m
     image:
-      registry: kuberhealthy
-      repository: dns-resolution-check
+      registry: docker.io
+      repository: kuberhealthy/dns-resolution-check
       tag: v1.5.0
     extraEnvs:
       HOSTNAME: "google.com"
@@ -203,8 +203,8 @@ check:
     runInterval: 5m
     timeout: 10m
     image:
-      registry: kuberhealthy
-      repository: pod-restarts-check
+      registry: docker.io
+      repository: kuberhealthy/pod-restarts-check
       tag: v2.5.0
     allNamespaces: false
     extraEnvs:
@@ -224,8 +224,8 @@ check:
     runInterval: 5m
     timeout: 15m
     image:
-      registry: kuberhealthy
-      repository: pod-status-check
+      registry: docker.io
+      repository: kuberhealthy/pod-status-check
       tag: v1.3.0
     allNamespaces: false
     extraEnvs: {}
@@ -250,8 +250,8 @@ check:
     runInterval: 5m
     timeout: 10m
     image:
-      registry: chrishirsch
-      repository: kuberhealthy-storage-check
+      registry: docker.io
+      repository: chrishirsch/kuberhealthy-storage-check
       tag: v0.0.1
     extraEnvs:
       CHECK_STORAGE_IMAGE: bitnami/nginx:1.19
@@ -271,8 +271,8 @@ check:
     runInterval: 30m
     timeout: 10m
     image:
-      registry: kuberhealthy
-      repository: network-connection-check
+      registry: docker.io
+      repository: kuberhealthy/network-connection-check
       tag: v0.2.0
     extraEnvs:
       CONNECTION_TARGET: "tcp://github.com:443"


### PR DESCRIPTION
Hi,

This PR fixes the handling of the `registry` variable in the `values.yaml`.

During my installation of kuberhealthy at my workplace, I wanted to set our internal Container Registry via the global `imageRegistry`. But, when setted the chart rendered the deployment without the `kuberhealty` for the Docker Hub repository part:


```bash
 containers:
      - image: docker.io/kuberhealthy:v2.7.1
        command: [/app/kuberhealthy]
        ports:

```
So, i set now the `registry` to `docker.io` and moved the former registry value to the repository part.

```bash
 containers:
      - image: docker.io/kuberhealthy/kuberhealthy:v2.7.1
        command: [/app/kuberhealthy]
        ports:

```

Now it works fine :)

Looking for your feedback.


FYI: @Kaktor