### PR TITLE
Fix securityContext for KH and few in-built checks for #1025

### DIFF
--- a/deploy/helm/kuberhealthy/Chart.yaml
+++ b/deploy/helm/kuberhealthy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: kuberhealthy
-appVersion: v2.7.2
+appVersion: v2.7.1
 version: 84
 home: https://kuberhealthy.github.io/kuberhealthy/
 description: "An operator for synthetic test and monitoring. Works great with Prometheus."

--- a/deploy/helm/kuberhealthy/Chart.yaml
+++ b/deploy/helm/kuberhealthy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kuberhealthy
-appVersion: v2.7.1
-version: 83
+appVersion: v2.7.2
+version: 84
 home: https://kuberhealthy.github.io/kuberhealthy/
 description: "An operator for synthetic test and monitoring. Works great with Prometheus."
 type: application

--- a/deploy/helm/kuberhealthy/templates/deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/deployment.yaml
@@ -85,6 +85,7 @@ spec:
           runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
           runAsUser: {{ .Values.securityContext.runAsUser }}
           allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+          readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
         imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}
         livenessProbe:
           failureThreshold: 3

--- a/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
@@ -42,6 +42,7 @@ spec:
         {{- end }}
 {{- if .Values.securityContext.enabled }}
       securityContext:
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
         allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
         readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
 {{- end}}

--- a/deploy/helm/kuberhealthy/templates/khcheck-dns-internal.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-dns-internal.yaml
@@ -46,6 +46,7 @@ spec:
           {{- end }}
         {{- if .Values.securityContext.enabled }}
         securityContext:
+          runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
           allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
           readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
         {{- end }}


### PR DESCRIPTION
Manual testing to verify the settings indeed work,

```
$ kubectl get khcheck deployment -n synthetic -o jsonpath='{.spec.podSpec.containers[*].securityContext}'
{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true}
```

```
$ kubectl get khcheck dns-status-internal -n synthetic -o jsonpath='{.spec.podSpec.containers[*].securityContext}'
{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true}
```

```
$ kubectl get pod kuberhealthy-7f755c7574-fknx6 -n synthetic -o=jsonpath='{.spec.containers[].securityContext}'
{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":999}
```

```
$ kubectl get pods -n synthetic -o wide
NAME                                     READY   STATUS      RESTARTS   AGE   IP             NODE                             NOMINATED NODE   READINESS GATES
deployment-1653574752                    1/1     Running     0          55s   10.58.71.143   aks-linux1-25436635-vmss000007   <none>           <none>
deployment-deployment-54849d45f6-fj6cn   1/1     Running     0          53s   10.58.71.152   aks-linux1-25436635-vmss000007   <none>           <none>
deployment-deployment-54849d45f6-fmqh4   1/1     Running     0          53s   10.58.71.142   aks-linux1-25436635-vmss000007   <none>           <none>
deployment-deployment-54849d45f6-wjdbd   1/1     Running     0          53s   10.58.71.145   aks-linux1-25436635-vmss000007   <none>           <none>
deployment-deployment-54849d45f6-xdmwd   1/1     Running     0          53s   10.58.71.149   aks-linux1-25436635-vmss000007   <none>           <none>
dns-status-internal-1653574752           0/1     Completed   0          55s   10.58.71.144   aks-linux1-25436635-vmss000007   <none>           <none>
kuberhealthy-656b4845c5-9kwlg            1/1     Running     0          19h   10.58.71.66    aks-xinfra-40004678-vmss00000l   <none>           <none>
kuberhealthy-656b4845c5-m89kb            1/1     Running     0          19h   10.58.71.103   aks-xinfra-40004678-vmss00000m   <none>           <none>
```
