### PR TITLE
fix: change Role to ClusterRole for dns internal check

### DIFF
--- a/deploy/helm/kuberhealthy/templates/khcheck-dns-internal.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-dns-internal.yaml
@@ -60,23 +60,9 @@ spec:
     serviceAccountName: dns-internal-sa
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRole
 metadata:
-  name: dns-internal-check-rb
-  namespace: {{ .Release.Namespace }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: dns-internal-service-role
-subjects:
-  - kind: ServiceAccount
-    name: dns-internal-sa
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: dns-internal-service-role
-  namespace: {{ .Release.Namespace }}
+  name: dns-internal-service-cr
 rules:
   - apiGroups:
       - ""
@@ -84,6 +70,19 @@ rules:
       - nodes
     verbs:
       - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dns-internal-service-crb
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: dns-internal-service-cr
+subjects:
+  - kind: ServiceAccount
+    name: dns-internal-sa
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
If we use Role and RoleBinding then ServiceAccount does not have permissions on the Node object at the cluster scope

Because of this, an error appears in the logs of the pod:
```
Error waiting for node to reach minimum age: nodes "basic-8cpu-16gb-cefnd" is forbidden: User "system:serviceaccount:kuberhealthy:dns-internal-sa" cannot get resource "nodes" in API group "" at the cluster scope
```