### PR TITLE
Support for Image Pull Secret in Deployment Check containers

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,3 +22,4 @@
 - [Zachary Hanson](mailto:Zachary_Hanson@comcast.com)
 - [Zhicheng Li](https://github.com/Hungrylion2019)
 - [Engin Diri](https://twitter.com/_ediri)
+- [McKenna Jones](https://github.com/mckennajones)

--- a/cmd/deployment-check/README.md
+++ b/cmd/deployment-check/README.md
@@ -39,6 +39,7 @@ This check follows the list of actions in order during the run of the check:
 
 - `CHECK_IMAGE`: Initial container image. (default=`nginxinc/nginx-unprivileged:1.17.8`)
 - `CHECK_IMAGE_ROLL_TO`: Container image to roll to. (default=`nginxinc/nginx-unprivileged:1.17.9`)
+- `CHECK_IMAGE_PULL_SECRET`: Name of Image Pull Secret to use for above images. 
 - `CHECK_DEPLOYMENT_NAME`: Name for the check's deployment. (default=`deployment-deployment`)
 - `CHECK_SERVICE_NAME`: Name for the check's service. (default=`deployment-svc`)
 - `CHECK_NAMESPACE`: Namespace for the check (default=`kuberhealthy`) The namespace that the `khcheck` CRD lives in will override this value.

--- a/cmd/deployment-check/deployment.go
+++ b/cmd/deployment-check/deployment.go
@@ -90,6 +90,12 @@ func createDeploymentConfig(image string) *v1.Deployment {
 		Tolerations:                   checkDeploymentTolerations,
 	}
 
+	if len(checkImagePullSecret) != 0 {
+		var secrets []corev1.LocalObjectReference
+		secrets = append(secrets, corev1.LocalObjectReference{Name: checkImagePullSecret})
+		podSpec.ImagePullSecrets = secrets
+	}
+
 	// Make labels for pod and deployment.
 	labels := make(map[string]string, 0)
 	labels[defaultLabelKey] = defaultLabelValueBase + strconv.Itoa(int(now.Unix()))

--- a/cmd/deployment-check/input.go
+++ b/cmd/deployment-check/input.go
@@ -49,6 +49,12 @@ func parseInputValues() {
 		log.Infoln("Parsed CHECK_IMAGE_ROLL_TO:", checkImageURLB)
 	}
 
+	// Parse image pull secret for check image
+	if len(checkImagePullSecretEnv) != 0 {
+		checkImagePullSecret = checkImagePullSecretEnv
+		log.Infoln("Parsed CHECK_IMAGE_PULL_SECRET:", checkImagePullSecret)
+	}
+
 	// Parse incoming check deployment name.
 	checkDeploymentName = defaultCheckDeploymentName
 	if len(checkDeploymentNameEnv) != 0 {

--- a/cmd/deployment-check/main.go
+++ b/cmd/deployment-check/main.go
@@ -28,6 +28,10 @@ var (
 	checkImageURLBEnv = os.Getenv("CHECK_IMAGE_ROLL_TO")
 	checkImageURLB    string
 
+	// Image Pull Secret for check pods
+	checkImagePullSecretEnv = os.Getenv("CHECK_IMAGE_PULL_SECRET")
+	checkImagePullSecret    string
+
 	// Deployment name that will be used for the check (in case an existing deployment uses a similar name).
 	checkDeploymentNameEnv = os.Getenv("CHECK_DEPLOYMENT_NAME")
 	checkDeploymentName    string


### PR DESCRIPTION
Adds a new env var to the deployment check container, to specify `imagePullSecrets` in the deployment child pods. Useful if you have a locked down K8s cluster where you only want to pull images from private registries. 