### PR TITLE
Fix scoping issue in storage check helm template

### DIFF
--- a/deploy/helm/kuberhealthy/Chart.yaml
+++ b/deploy/helm/kuberhealthy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kuberhealthy
 appVersion: v2.7.1
-version: 90
+version: 91
 home: https://kuberhealthy.github.io/kuberhealthy/
 description: "An operator for synthetic test and monitoring. Works great with Prometheus."
 type: application

--- a/deploy/helm/kuberhealthy/templates/khcheck-storage.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-storage.yaml
@@ -16,9 +16,9 @@ spec:
       runAsUser: {{ $.Values.securityContext.runAsUser }}
       fsGroup: {{ $.Values.securityContext.fsGroup }}
     {{- end }}
-    {{- if .Values.imagePullSecrets }}
+    {{- if $.Values.imagePullSecrets }}
     imagePullSecrets:
-      {{ toYaml .Values.imagePullSecrets | indent 2 }}
+      {{ toYaml $.Values.imagePullSecrets | indent 2 }}
     {{- end }}
     containers:
     - name: main


### PR DESCRIPTION
Correctly refer to the top-level `imagePullSecrets` value.