### PR TITLE
Add seccompProfile parameter to the securityContext document for kuberhealthy pods

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -24,3 +24,4 @@
 - [Engin Diri](https://twitter.com/_ediri)
 - [Joel Kulesa](https://github.com/jkulesa)
 - [McKenna Jones](https://github.com/mckennajones)
+- [Erich Stoekl](https://github.com/erichstoekl)

--- a/deploy/helm/kuberhealthy/templates/deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/deployment.yaml
@@ -92,6 +92,10 @@ spec:
           runAsUser: {{ .Values.securityContext.runAsUser }}
           allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
           readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+          {{- if .Values.securityContext.seccompProfile }}
+          seccompProfile:
+            {{- toYaml .Values.securityContext.seccompProfile | nindent 12 }}
+          {{- end }}
         imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}
         livenessProbe:
           failureThreshold: 3

--- a/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
@@ -16,6 +16,10 @@ spec:
     securityContext:
       runAsUser: {{ .Values.securityContext.runAsUser }}
       fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- if .Values.securityContext.seccompProfile }}
+      seccompProfile:
+        {{- toYaml .Values.securityContext.seccompProfile | nindent 8 }}
+      {{- end }}
     {{- end}}
     {{- if .Values.imagePullSecrets }}
     imagePullSecrets:

--- a/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
@@ -13,6 +13,10 @@ spec:
     securityContext:
       runAsUser: {{ .Values.securityContext.runAsUser }}
       fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- if .Values.securityContext.seccompProfile }}
+      seccompProfile:
+        {{- toYaml .Values.securityContext.seccompProfile | nindent 8 }}
+      {{- end }}
     {{- end}}
     {{- if .Values.imagePullSecrets }}
     imagePullSecrets:

--- a/deploy/helm/kuberhealthy/templates/khcheck-dns-external.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-dns-external.yaml
@@ -13,6 +13,10 @@ spec:
     securityContext:
       runAsUser: {{ .Values.securityContext.runAsUser }}
       fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- if .Values.securityContext.seccompProfile }}
+      seccompProfile:
+        {{- toYaml .Values.securityContext.seccompProfile | nindent 8 }}
+      {{- end }}
     {{- end}}
     {{- if .Values.imagePullSecrets }}
     imagePullSecrets:

--- a/deploy/helm/kuberhealthy/templates/khcheck-dns-internal.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-dns-internal.yaml
@@ -13,6 +13,10 @@ spec:
     securityContext:
       runAsUser: {{ .Values.securityContext.runAsUser }}
       fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- if .Values.securityContext.seccompProfile }}
+      seccompProfile:
+        {{- toYaml .Values.securityContext.seccompProfile | nindent 8 }}
+      {{- end }}
     {{- end}}
     {{- if .Values.imagePullSecrets }}
     imagePullSecrets:

--- a/deploy/helm/kuberhealthy/templates/khcheck-network-connection.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-network-connection.yaml
@@ -9,6 +9,11 @@ spec:
   runInterval:  {{ .Values.check.networkConnection.runInterval }}
   timeout: {{ .Values.check.networkConnection.timeout }}
   podSpec:
+    {{- if .Values.securityContext.seccompProfile }}
+    securityContext:
+      seccompProfile:
+        {{- toYaml .Values.securityContext.seccompProfile | nindent 8 }}
+    {{- end }}
     {{- if .Values.imagePullSecrets }}
     imagePullSecrets:
       {{ toYaml .Values.imagePullSecrets | indent 2 }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-restarts.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-restarts.yaml
@@ -12,6 +12,10 @@ spec:
     securityContext:
       runAsUser: {{ .Values.securityContext.runAsUser }}
       fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- if .Values.securityContext.seccompProfile }}
+      seccompProfile:
+        {{- toYaml .Values.securityContext.seccompProfile | nindent 8 }}
+      {{- end }}
     {{- end}}
     {{- if .Values.imagePullSecrets }}
     imagePullSecrets:

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
@@ -12,6 +12,10 @@ spec:
     securityContext:
       runAsUser: {{ .Values.securityContext.runAsUser }}
       fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- if .Values.securityContext.seccompProfile }}
+      seccompProfile:
+        {{- toYaml .Values.securityContext.seccompProfile | nindent 8 }}
+      {{- end }}
     {{- end}}
     {{- if .Values.imagePullSecrets }}
     imagePullSecrets:

--- a/deploy/helm/kuberhealthy/templates/khcheck-storage.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-storage.yaml
@@ -15,6 +15,10 @@ spec:
     securityContext:
       runAsUser: {{ $.Values.securityContext.runAsUser }}
       fsGroup: {{ $.Values.securityContext.fsGroup }}
+      {{- if $.Values.securityContext.seccompProfile }}
+      seccompProfile:
+        {{- toYaml $.Values.securityContext.seccompProfile | nindent 8 }}
+      {{- end }}
     {{- end }}
     {{- if $.Values.imagePullSecrets }}
     imagePullSecrets:

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -107,6 +107,8 @@ securityContext:
   fsGroup: 999
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
+  #seccompProfile:
+  #  type: RuntimeDefault
 
 # When enabled kuberhealthy will create a PodSecurityPolicy, Role and Binding to match the specified securityContext
 # In case you use your own images for tests, you might need to add other PSPs as well on your own


### PR DESCRIPTION
# Description
This PR is to address the issue: #1109 

In this PR we add the configuration option to enable `seccompProfile` for pods created by kuberhealthy. We do so by adding conditions to yaml templates, wherein if the `seccompProfile` object exists in `values.yaml`, it will be applied to the relevant templates.

# Testing
This change was tested on minikube by enabling all relevant `checks` with the `seccompProfile` object in place (set to `type: RuntimeDefault`). The Helm chart successfully applies and pods spawn normally.