### PR TITLE
Add status to khcheck and khjob

### DIFF
--- a/.ci/_job_test.sh
+++ b/.ci/_job_test.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# ========== Utility functions ==========
+function get_khjob_status_ok {
+    kubectl get khjob -n $NS kh-test-job -ojsonpath='{.status.ok}'
+}
+
+function get_khstate_ok {
+    kubectl get khstate -n $NS kh-test-job -ojsonpath='{.spec.OK}'
+}
+
+function job_phase {
+    kubectl get khjob -n $NS kh-test-job -ojsonpath='{.spec.phase}'
+}
+
+function fail_test {
+    # Print debug_information
+    echo ---
+    kubectl get khjob -n $NS kh-test-job -oyaml
+    echo ---
+    kubectl get khstate -n $NS kh-test-job -oyaml
+    exit 1
+}
+
+echo ========== Job E2E test - Job successful case ==========
+sed s/REPORT_FAILURE_VALUE/false/ .ci/khjob.yaml |kubectl apply -n $NS -f-
+
+if [ "$(get_khjob_status_ok)" != "" ]; then
+    echo "There should not be any OK field initially"; fail_test
+fi
+
+if [ "$(job_phase)" != "Running" ]; then
+    echo "Job should be in running phase"; fail_test
+fi
+
+# Wait until the field is available
+TIMEOUT=30
+while [ "$(job_phase)" == "Running" ] && [ $TIMEOUT -gt 0 ]; do sleep 1; echo Job phase: $(job_phase), timeout: ${TIMEOUT}; let TIMEOUT-=1; done
+
+# Check the result
+if [ "$(get_khjob_status_ok)" != "true" ]; then
+    echo "khjob status should have returned OK"; fail_test
+fi
+
+if [ "$(get_khstate_ok)" != "true" ]; then
+    echo "khstate should have returned OK"; fail_test
+fi
+
+if [ "$(job_phase)" != "Completed" ]; then
+    echo "Job phase should be Completed."; fail_test
+fi
+
+# Delete the job
+kubectl delete khjob -n $NS kh-test-job
+
+
+
+echo ========== Job E2E test - Job fail case ==========
+
+sed s/REPORT_FAILURE_VALUE/true/ .ci/khjob.yaml |kubectl apply -n $NS -f-
+
+if [ "$(get_khjob_status_ok)" != "" ]; then
+    echo "There should not be any OK field initially"; fail_test
+fi
+
+if [ "$(job_phase)" != "Running" ]; then
+    echo "Job should be in running phase"; fail_test
+fi
+
+# Wait until the field is available
+TIMEOUT=30
+while [ "$(job_phase)" == "Running" ] && [ $TIMEOUT -gt 0 ]; do sleep 1; echo Job phase: $(job_phase), timeout: ${TIMEOUT}; let TIMEOUT-=1; done
+
+# Check the result
+if [ "$(get_khjob_status_ok)" != "false" ]; then
+    echo "khjob status should have NOT returned OK"; fail_test
+fi
+
+if [ "$(get_khstate_ok)" != "false" ]; then
+    echo "khstate should have NOT returned OK"; fail_test
+fi
+
+if [ "$(job_phase)" != "Completed" ]; then
+    echo "Job phase should be Completed."; fail_test
+fi
+
+# Delete the job
+kubectl delete khjob -n $NS kh-test-job

--- a/.ci/e2e.sh
+++ b/.ci/e2e.sh
@@ -58,6 +58,7 @@ kubectl logs -n $NS --selector $selector
 for i in {1..60}
 do
     khsCount=$(kubectl get -n $NS khs -o yaml |grep "OK: true" |wc -l)
+    kcStatusCount=$(kubectl get -n $NS khcheck -o yaml |grep "ok: true" |wc -l)
     cDeploy=$(kubectl -n $NS get pods -l app=kuberhealthy-check |grep deployment |grep Completed |wc -l)
     cDNS=$(kubectl -n $NS get pods -l app=kuberhealthy-check |grep dns-status-internal |grep Completed |wc -l)
     cDS=$(kubectl -n $NS get pods -l app=kuberhealthy-check |grep daemonset |grep Completed |wc -l)
@@ -65,7 +66,7 @@ do
     cPS=$(kubectl -n $NS get pods -l app=kuberhealthy-check |grep pod-status |grep Completed |wc -l)
     failCount=$(kubectl get -n $NS khs -o yaml |grep "OK: false" |wc -l)
 
-    if [ $khsCount -ge 5 ] && [ $cDeploy -ge 1 ] && [ $cDS -ge 1 ] && [ $cDNS -ge 1 ] && [ $cPR -ge 1 ] && [ $cPS -ge 1 ]
+    if [ $khsCount -ge 5 ] && [ $khsCount -eq $kcStatusCount ] && [ $cDeploy -ge 1 ] && [ $cDS -ge 1 ] && [ $cDNS -ge 1 ] && [ $cPR -ge 1 ] && [ $cPS -ge 1 ]
     then
         echo "Kuberhealthy is working like it should and all tests passed"
         break
@@ -113,3 +114,5 @@ then
 else
     echo "No Error deployment pods found"
 fi
+
+. .ci/_job_test.sh

--- a/.ci/khjob.yaml
+++ b/.ci/khjob.yaml
@@ -1,0 +1,20 @@
+apiVersion: comcast.github.io/v1
+kind: KuberhealthyJob
+metadata:
+  name: kh-test-job
+spec:
+  timeout: 2m
+  podSpec:
+    containers:
+    - env:
+      - name: REPORT_FAILURE
+        value: "REPORT_FAILURE_VALUE"
+      - name: REPORT_DELAY
+        value: 5s
+      image: kuberhealthy/test-check:latest
+      imagePullPolicy: Always
+      name: main
+      resources:
+        requests:
+          cpu: 10m
+          memory: 50Mi

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -26,3 +26,4 @@
 - [McKenna Jones](https://github.com/mckennajones)
 - [Allan Ramirez](https://github.com/ramirezag)
 - [Erich Stoekl](https://github.com/erichstoekl)
+- [Ugur Zongur](https://github.com/ugurzongur)

--- a/deploy/helm/kuberhealthy/crds/comcast.github.io_khchecks.yaml
+++ b/deploy/helm/kuberhealthy/crds/comcast.github.io_khchecks.yaml
@@ -19,7 +19,20 @@ spec:
   scope: Namespaced
   preserveUnknownFields: false
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: OK status
+      jsonPath: .status.ok
+      name: OK
+      type: string
+    - description: Last Run
+      jsonPath: .status.lastRun
+      name: Age LastRun
+      type: date
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: KuberhealthyCheck represents the data in the CRD for configuring
@@ -6451,9 +6464,40 @@ spec:
             - runInterval
             - timeout
             type: object
+          status:
+            description: Status holds the results of the last run
+            properties:
+              authoritativePod:
+                type: string
+              errors:
+                items:
+                  type: string
+                type: array
+              lastRun:
+                format: date-time
+                nullable: true
+                type: string
+              node:
+                type: string
+              ok:
+                type: boolean
+              runDuration:
+                type: string
+              uuid:
+                type: string
+            required:
+            - authoritativePod
+            - errors
+            - node
+            - ok
+            - runDuration
+            - uuid
+            type: object
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/deploy/helm/kuberhealthy/crds/comcast.github.io_khjobs.yaml
+++ b/deploy/helm/kuberhealthy/crds/comcast.github.io_khjobs.yaml
@@ -19,7 +19,20 @@ spec:
   scope: Namespaced
   preserveUnknownFields: false
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: OK status
+      jsonPath: .status.ok
+      name: OK
+      type: string
+    - description: Last Run
+      jsonPath: .status.lastRun
+      name: Age LastRun
+      type: date
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: KuberhealthyJob represents the data in the CRD for configuring
@@ -6452,9 +6465,40 @@ spec:
             - podSpec
             - timeout
             type: object
+          status:
+            description: Status holds the results of the job
+            properties:
+              authoritativePod:
+                type: string
+              errors:
+                items:
+                  type: string
+                type: array
+              lastRun:
+                format: date-time
+                nullable: true
+                type: string
+              node:
+                type: string
+              ok:
+                type: boolean
+              runDuration:
+                type: string
+              uuid:
+                type: string
+            required:
+            - authoritativePod
+            - errors
+            - node
+            - ok
+            - runDuration
+            - uuid
+            type: object
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/deploy/helm/kuberhealthy/templates/clusterrole.yaml
+++ b/deploy/helm/kuberhealthy/templates/clusterrole.yaml
@@ -52,6 +52,13 @@ rules:
     verbs:
     - "*"
   - apiGroups:
+    - comcast.github.io
+    resources:
+    - khchecks/status
+    - khjobs/status
+    verbs:
+    - "*"
+  - apiGroups:
     - ""
     resources:
     - namespaces

--- a/pkg/apis/khcheck/v1/kuberhealthycheck.go
+++ b/pkg/apis/khcheck/v1/kuberhealthycheck.go
@@ -38,6 +38,7 @@ type KuberhealthyChecksGetter interface {
 type KuberhealthyCheckInterface interface {
 	Create(*KuberhealthyCheck) (KuberhealthyCheck, error)
 	Update(*KuberhealthyCheck) (KuberhealthyCheck, error)
+	UpdateStatus(*KuberhealthyCheck) (KuberhealthyCheck, error)
 	Delete(name string, options *metav1.DeleteOptions) error
 	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions) (KuberhealthyCheck, error)
@@ -124,6 +125,21 @@ func (c *kuberhealthyChecks) Update(kuberhealthyCheck *KuberhealthyCheck) (resul
 		Namespace(c.ns).
 		Resource("khchecks").
 		Name(kuberhealthyCheck.Name).
+		Body(kuberhealthyCheck).
+		Do(context.TODO()).
+		Into(&result)
+	return
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *kuberhealthyChecks) UpdateStatus(kuberhealthyCheck *KuberhealthyCheck) (result KuberhealthyCheck, err error) {
+	result = KuberhealthyCheck{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("khchecks").
+		Name(kuberhealthyCheck.Name).
+		SubResource("status").
 		Body(kuberhealthyCheck).
 		Do(context.TODO()).
 		Into(&result)

--- a/pkg/apis/khcheck/v1/types.go
+++ b/pkg/apis/khcheck/v1/types.go
@@ -11,9 +11,13 @@ import (
 // KuberhealthyCheck represents the data in the CRD for configuring an
 // external check for Kuberhealthy
 // +k8s:openapi-gen=true
+// +kubebuilder:printcolumn:name="OK",type=string,JSONPath=`.status.ok`,description="OK status"
+// +kubebuilder:printcolumn:name="Age LastRun",type=date,JSONPath=`.status.lastRun`,description="Last Run"
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 // +kubebuilder:resource:path="khchecks"
 // +kubebuilder:resource:singular="khcheck"
 // +kubebuilder:resource:shortName="khc"
+// +kubebuilder:subresource:status
 type KuberhealthyCheck struct {
 	metav1.TypeMeta `json:",inline" yaml:",inline"`
 	// +optional
@@ -22,6 +26,9 @@ type KuberhealthyCheck struct {
 	// Spec holds the desired state of the KuberhealthyCheck (from the client).
 	// +optional
 	Spec CheckConfig `json:"spec,omitempty" yaml:"spec,omitempty"`
+
+	// Status holds the results of the last run
+	Status CheckStatus `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
 // CheckConfig represents a configuration for a kuberhealthy external
@@ -37,6 +44,17 @@ type CheckConfig struct {
 	ExtraAnnotations map[string]string `json:"extraAnnotations" yaml:"extraAnnotations"` // a map of extra annotations that will be applied to the pod
 	// +optional
 	ExtraLabels map[string]string `json:"extraLabels" yaml:"extraLabels"` // a map of extra labels that will be applied to the pod
+}
+
+type CheckStatus struct {
+	OK          bool     `json:"ok" yaml:"ok"`                   // true or false status of the check, whether or not it completed successfully
+	Errors      []string `json:"errors" yaml:"errors"`           // the list of errors reported from the check run
+	RunDuration string   `json:"runDuration" yaml:"runDuration"` // the time it took for the check to complete
+	Node        string   `json:"node" yaml:"node"`               // the node the check ran on
+	// +nullable
+	LastRun          *metav1.Time `json:"lastRun,omitempty" yaml:"lastRun,omitempty"` // the time the check was last run
+	AuthoritativePod string       `json:"authoritativePod" yaml:"authoritativePod"`   // the main kuberhealthy pod creating and updating the status
+	CurrentUUID      string       `json:"uuid" yaml:"uuid"`                           // the UUID that is authorized to report statuses into the kuberhealthy endpoint
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/khjob/v1/kuberhealthyjob.go
+++ b/pkg/apis/khjob/v1/kuberhealthyjob.go
@@ -38,6 +38,7 @@ type KuberhealthyJobsGetter interface {
 type KuberhealthyJobInterface interface {
 	Create(*KuberhealthyJob) (KuberhealthyJob, error)
 	Update(*KuberhealthyJob) (KuberhealthyJob, error)
+	UpdateStatus(*KuberhealthyJob) (KuberhealthyJob, error)
 	Delete(name string, options *metav1.DeleteOptions) error
 	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions) (KuberhealthyJob, error)
@@ -124,6 +125,21 @@ func (c *kuberhealthyJobs) Update(kuberhealthyJob *KuberhealthyJob) (result Kube
 		Namespace(c.ns).
 		Resource("khjobs").
 		Name(kuberhealthyJob.Name).
+		Body(kuberhealthyJob).
+		Do(context.TODO()).
+		Into(&result)
+	return
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *kuberhealthyJobs) UpdateStatus(kuberhealthyJob *KuberhealthyJob) (result KuberhealthyJob, err error) {
+	result = KuberhealthyJob{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("khjobs").
+		Name(kuberhealthyJob.Name).
+		SubResource("status").
 		Body(kuberhealthyJob).
 		Do(context.TODO()).
 		Into(&result)

--- a/pkg/apis/khjob/v1/types.go
+++ b/pkg/apis/khjob/v1/types.go
@@ -11,9 +11,13 @@ import (
 // KuberhealthyJob represents the data in the CRD for configuring an
 // external checker job for Kuberhealthy
 // +k8s:openapi-gen=true
+// +kubebuilder:printcolumn:name="OK",type=string,JSONPath=`.status.ok`,description="OK status"
+// +kubebuilder:printcolumn:name="Age LastRun",type=date,JSONPath=`.status.lastRun`,description="Last Run"
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 // +kubebuilder:resource:path="khjobs"
 // +kubebuilder:resource:singular="khjob"
 // +kubebuilder:resource:shortName="khj"
+// +kubebuilder:subresource:status
 type KuberhealthyJob struct {
 	metav1.TypeMeta `json:",inline" yaml:",inline"`
 	// +optional
@@ -22,6 +26,9 @@ type KuberhealthyJob struct {
 	// Spec holds the desired state of the KuberhealthyJob (from the client).
 	// +optional
 	Spec JobConfig `json:"spec,omitempty" yaml:"spec,omitempty"`
+
+	// Status holds the results of the job
+	Status JobStatus `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
 // JobConfig represents a configuration for a kuberhealthy external
@@ -38,6 +45,17 @@ type JobConfig struct {
 	ExtraAnnotations map[string]string `json:"extraAnnotations" yaml:"extraAnnotations"` // a map of extra annotations that will be applied to the pod
 	// +optional
 	ExtraLabels map[string]string `json:"extraLabels" yaml:"extraLabels"` // a map of extra labels that will be applied to the pod
+}
+
+type JobStatus struct {
+	OK          bool     `json:"ok" yaml:"ok"`                   // true or false status of the job, whether or not it completed successfully
+	Errors      []string `json:"errors" yaml:"errors"`           // the list of errors reported from the job run
+	RunDuration string   `json:"runDuration" yaml:"runDuration"` // the time it took for the job to complete
+	Node        string   `json:"node" yaml:"node"`               // the node the job ran on
+	// +nullable
+	LastRun          *metav1.Time `json:"lastRun,omitempty" yaml:"lastRun,omitempty"` // the time the job was last run
+	AuthoritativePod string       `json:"authoritativePod" yaml:"authoritativePod"`   // the main kuberhealthy pod creating and updating the state
+	CurrentUUID      string       `json:"uuid" yaml:"uuid"`                           // the UUID that is authorized to report statuses into the kuberhealthy endpoint
 }
 
 // JobPhase is a label for the condition of the job at the current time.

--- a/scripts/generated/comcast.github.io_khchecks.yaml
+++ b/scripts/generated/comcast.github.io_khchecks.yaml
@@ -19,7 +19,20 @@ spec:
   scope: Namespaced
   preserveUnknownFields: false
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: OK status
+      jsonPath: .status.ok
+      name: OK
+      type: string
+    - description: Last Run
+      jsonPath: .status.lastRun
+      name: Age LastRun
+      type: date
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: KuberhealthyCheck represents the data in the CRD for configuring
@@ -6451,9 +6464,40 @@ spec:
             - runInterval
             - timeout
             type: object
+          status:
+            description: Status holds the results of the last run
+            properties:
+              authoritativePod:
+                type: string
+              errors:
+                items:
+                  type: string
+                type: array
+              lastRun:
+                format: date-time
+                nullable: true
+                type: string
+              node:
+                type: string
+              ok:
+                type: boolean
+              runDuration:
+                type: string
+              uuid:
+                type: string
+            required:
+            - authoritativePod
+            - errors
+            - node
+            - ok
+            - runDuration
+            - uuid
+            type: object
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/scripts/generated/comcast.github.io_khjobs.yaml
+++ b/scripts/generated/comcast.github.io_khjobs.yaml
@@ -19,7 +19,20 @@ spec:
   scope: Namespaced
   preserveUnknownFields: false
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: OK status
+      jsonPath: .status.ok
+      name: OK
+      type: string
+    - description: Last Run
+      jsonPath: .status.lastRun
+      name: Age LastRun
+      type: date
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: KuberhealthyJob represents the data in the CRD for configuring
@@ -6452,9 +6465,40 @@ spec:
             - podSpec
             - timeout
             type: object
+          status:
+            description: Status holds the results of the job
+            properties:
+              authoritativePod:
+                type: string
+              errors:
+                items:
+                  type: string
+                type: array
+              lastRun:
+                format: date-time
+                nullable: true
+                type: string
+              node:
+                type: string
+              ok:
+                type: boolean
+              runDuration:
+                type: string
+              uuid:
+                type: string
+            required:
+            - authoritativePod
+            - errors
+            - node
+            - ok
+            - runDuration
+            - uuid
+            type: object
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
Fixes #1120

After changing the `types.go` files for `khjob` and `khcheck`, I manually edited `pkg/apis/khjob/v1/kuberhealthyjob.go` and `pkg/apis/khcheck/v1/kuberhealthycheck.go` files respectively because I couldn't replicate the method that was used to generate those files. This is also mentioned in #1055. I tried current and older versions of https://github.com/kubernetes/code-generator with various parameters but they all ended up being quite different from the existing files especially in terms of folder structure. I believe those files are a combination of auto-generation and post-editing. IMHO that needs to be fixed eventually.