### PR TITLE
Allow to provide annotations and additional labels for the grafana dashboard

### DIFF
--- a/deploy/helm/kuberhealthy/templates/grafana-dashboard.yaml
+++ b/deploy/helm/kuberhealthy/templates/grafana-dashboard.yaml
@@ -7,6 +7,10 @@ metadata:
     {{- if .Values.prometheus.grafanaDashboard.additionalLabels}}
     {{- toYaml .Values.prometheus.grafanaDashboard.additionalLabels | nindent 4 }}
     {{- end }}
+  {{- if .Values.prometheus.grafanaDashboard.annotations}}
+  annotations:
+    {{- toYaml .Values.prometheus.grafanaDashboard.annotations | nindent 4 }}
+  {{- end }}
   name: grafana-kuberhealthy
   {{- if .Values.prometheus.grafanaDashboard.namespace }}
   namespace: {{ .Values.prometheus.grafanaDashboard.namespace }}

--- a/deploy/helm/kuberhealthy/templates/grafana-dashboard.yaml
+++ b/deploy/helm/kuberhealthy/templates/grafana-dashboard.yaml
@@ -4,6 +4,9 @@ kind: ConfigMap
 metadata:
   labels:
     {{ .Values.prometheus.grafanaDashboard.label }}: {{ .Values.prometheus.grafanaDashboard.labelValue | quote }}
+    {{- if .Values.prometheus.grafanaDashboard.additionalLabels}}
+    {{- toYaml .Values.prometheus.grafanaDashboard.additionalLabels | nindent 4 }}
+    {{- end }}
   name: grafana-kuberhealthy
   {{- if .Values.prometheus.grafanaDashboard.namespace }}
   namespace: {{ .Values.prometheus.grafanaDashboard.namespace }}

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -17,6 +17,9 @@ prometheus:
     enabled: false
     label: grafana_dashboard
     labelValue: "1"
+    additionalLabels: {}
+      # env: "dev"
+      # mycustomlabel: "value"
     # namespace: "" # Alternative namespace to use for grafana dashboard.
 
   serviceMonitor:

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -20,6 +20,8 @@ prometheus:
     additionalLabels: {}
       # env: "dev"
       # mycustomlabel: "value"
+    annotations: {}
+      # k8s-sidecar-target-directory: "kuberhealthy"
     # namespace: "" # Alternative namespace to use for grafana dashboard.
 
   serviceMonitor:


### PR DESCRIPTION
This PR allows to specify annotations and additionalLabels on the grafanaDashboard.

By specifying the annotation `k8s-sidecar-target-directory:target-folder,` the dashboard can be deployed to a specific folder in Grafana.

Additional annotations can be provided as on the `serviceMonitor` and the `prometheusRule`.

Fixes: #1132 

