### PR TITLE
move pod disruption budget away from v1beta1 awlays

### DIFF
--- a/deploy/helm/kuberhealthy/templates/poddisruptionbudget.yaml
+++ b/deploy/helm/kuberhealthy/templates/poddisruptionbudget.yaml
@@ -1,10 +1,6 @@
 ---
 {{- if .Values.podDisruptionBudget.enabled }}
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
 apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name:  {{ template "kuberhealthy.name" . }}-pdb


### PR DESCRIPTION
- Removes `v1beta/poddisruptionbudget` support
