### PR TITLE
move away from unstructured watcher

### DIFF
--- a/cmd/kuberhealthy/kuberhealthy.go
+++ b/cmd/kuberhealthy/kuberhealthy.go
@@ -445,7 +445,8 @@ func (k *Kuberhealthy) watchForKHCheckChanges(ctx context.Context, c chan struct
 		time.Sleep(time.Second)
 
 		// start a watch on khcheck resources
-		watcher, err := watchUnstructuredKHChecks(ctx, k.TargetNamespace)
+		watcher, err := khCheckClient.KuberhealthyChecks(k.TargetNamespace).Watch(metav1.ListOptions{})
+		// watcher, err := watchUnstructuredKHChecks(ctx, k.TargetNamespace)
 		if err != nil {
 			log.Errorln("error creating watcher for khcheck objects:", err)
 			continue


### PR DESCRIPTION
The unstructured watcher is causing errors on start:

```
time="2024-01-03T06:32:21Z" level=error msg="error creating watcher for khcheck objects: the server rejected our request for an unknown reason"
time="2024-01-03T06:32:21Z" level=debug msg="Starting a watch for khcheck object changes"
```
