### PR TITLE
Adds dns-external-sa serviceAccount, CR and CRB

### DIFF
--- a/deploy/helm/kuberhealthy/templates/khcheck-dns-external.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-dns-external.yaml
@@ -66,3 +66,36 @@ spec:
 {{- toYaml .Values.check.dnsExternal.tolerations | nindent 6 }}
     {{- end }}
 {{- end }}
+    serviceAccountName: dns-external-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dns-external-service-cr
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dns-external-service-crb
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: dns-external-service-cr
+subjects:
+  - kind: ServiceAccount
+    name: dns-external-sa
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dns-external-sa
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-dns-external.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-dns-external.yaml
@@ -65,7 +65,6 @@ spec:
     tolerations:
 {{- toYaml .Values.check.dnsExternal.tolerations | nindent 6 }}
     {{- end }}
-{{- end }}
     serviceAccountName: dns-external-sa
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This PR fixes an error when running the external DNS check. The Helm chart deploys the KuberhealthyCheck without a service account defined so it uses the default service account. The default service account does not have the correct permissions to do a get on the nodes. This PR creates a service account called dns-external-sa and creates the proper roles.