### PR TITLE
Add Stale Issue Closing GitHub Action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,16 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment on the issue or this will be closed in 15 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 15 days with no activity. Please reopen and comment on the issue if you believe it should stay open.'
+          days-before-stale: 30
+          days-before-close: 15
+          exempt-issue-labels: 'in progress, do-not-close'


### PR DESCRIPTION
# Purpose

This PR add the action for stale issue closing (https://github.com/marketplace/actions/close-stale-issues) and configures issues to be closed on the following cadence:

- If no activity for **30 days** bot will comment on the issue indicating it is stale
- After **another 15 days** of no activity the bot will close the PR

The action will ignore an issue with `in progress` or `do-not-close` so that long-running issues will not be spammed if there are periods of inactivity and prematurely closed.