### PR TITLE
feat: renovate configuration

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -30,3 +30,4 @@
 - [Stefan Tertan](https://github.com/ColdFire87)
 - [Ajay Kalambur](https://github.com/kalamburajay)
 - [Lorenzo Setale](https://setale.me/)
+- [Rachel Sheikh](https://github.com/sheikhrachel)

--- a/default.json5
+++ b/default.json5
@@ -1,0 +1,61 @@
+// docs: https://docs.renovatebot.com
+{
+  automerge: true,
+  automergeStrategy: 'auto',
+  automergeType: 'pr',
+  platformAutomerge: true,
+  commitBodyTable: true,
+  dependencyDashboard: true,
+  // more managers: https://docs.renovatebot.com/modules/manager
+  enabledManagers: [
+    'gomod',
+  ],
+  extends: [
+    ':disablePrControls'
+  ],
+  gitAuthor: "rachel-renovate <sheikhrachel97@gmail.com>",
+  gitIgnoredAuthors: [
+    "renovate@whitesourcesoftware.com",
+    "sheikhrachel97@gmail.com",
+  ],
+  rebaseWhen: 'auto',
+  semanticCommitType: 'chore',
+  semanticCommits: 'enabled',
+  separateMajorMinor: true,
+  separateMinorPatch: false,
+  separateMultipleMajor: false,
+  schedule: 'after 7am and before 2pm every weekday',
+  postUpdateOptions: [
+    'gomodTidy',
+    'gomodUpdateImportPaths',
+  ],
+  prBodyDefinitions: {
+    Package: '{{{depNameLinked}}}',
+    Type: '{{{depType}}}',
+    Update: '{{{updateType}}}',
+    'Current value': '{{{currentValue}}}',
+    'New value': '{{{newValue}}}',
+    Change: '`{{{displayFrom}}}` -> `{{{displayTo}}}`',
+    Pending: '{{{displayPending}}}',
+    References: '{{{references}}}',
+    'Package file': '{{{packageFile}}}',
+    Manager: '{{{manager}}}',
+  },
+  prBodyColumns: [
+    'Package',
+    'Type',
+    'Package file',
+    'Manager',
+    'Update',
+    'Change',
+    'Pending',
+  ],
+  vulnerabilityAlerts: {
+    addLabels: [
+      'security',
+    ],
+    semanticCommitType: 'fix',
+    schedule: 'at any time',
+  },
+  timezone: 'America/Los_Angeles',
+}

--- a/default.json5
+++ b/default.json5
@@ -7,12 +7,8 @@
   commitBodyTable: true,
   dependencyDashboard: true,
   // more managers: https://docs.renovatebot.com/modules/manager
-  enabledManagers: [
-    'gomod',
-  ],
-  extends: [
-    ':disablePrControls'
-  ],
+  enabledManagers: ['gomod'],
+  extends: [':disablePrControls'],
   gitAuthor: "rachel-renovate <sheikhrachel97@gmail.com>",
   gitIgnoredAuthors: [
     "renovate@whitesourcesoftware.com",
@@ -23,6 +19,17 @@
   semanticCommits: 'enabled',
   separateMajorMinor: true,
   separateMinorPatch: false,
+  "packageRules": [
+    {
+      "updateTypes": ["patch", "minor"],
+      "automerge": true,
+      "groupName": "Patch/Minor Updates"
+    },
+    {
+      "updateTypes": ["major"],
+      "automerge": false,
+    }
+  ],
   separateMultipleMajor: false,
   schedule: 'after 7am and before 2pm every weekday',
   postUpdateOptions: [
@@ -51,9 +58,7 @@
     'Pending',
   ],
   vulnerabilityAlerts: {
-    addLabels: [
-      'security',
-    ],
+    addLabels: ['security'],
     semanticCommitType: 'fix',
     schedule: 'at any time',
   },

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>sheikhrachel/workbench:default.json5"
+  ]
+}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>sheikhrachel/workbench:default.json5"
+    "github>kuberhealthy/kuberhealthy:default.json5"
   ]
 }


### PR DESCRIPTION
# Purpose

Introduces a [renovate](https://docs.renovatebot.com) configuration to assist with dependency tracking and updates.

Example of the automated PRs expected as a result of this change: https://github.com/sheikhrachel/Reverbed/pull/10

## TODO

Configure the official [Renovate Github App](https://github.com/apps/renovate) in the Kuberhealthy Repo settings to enable renovate watching