### PR TITLE
Fixing Khcheck http-check unexpected status code and expected status code are both logged as Error

### DIFF
--- a/cmd/http-check/main.go
+++ b/cmd/http-check/main.go
@@ -173,9 +173,9 @@ func main() {
 			log.Errorln("Got a", r.StatusCode, "with a", http.MethodGet, "to", parsedUrl.Redacted())
 			checksFailed++
 			continue
-		}
-		log.Infoln("Got a", r.StatusCode, "with a", http.MethodGet, "to", parsedUrl.Redacted())
-		checksPassed++
+		} else {
+		    log.Infoln("Got a", r.StatusCode, "with a", http.MethodGet, "to", parsedUrl.Redacted())
+		    checksPassed++
 
 		// if we have a ticker, we wait for it to tick before checking again
 		if ticker != nil && ticker.C != nil {


### PR DESCRIPTION
fixes: #1104 

I have added an else condition which should work. If the `StatusCode is equal to expectedStatusCode` then the else block should run. Currently it logs both the expected and unexpected conditions