### PR TITLE
fix(helm): pass extraAnnotations and extraLabels to khchecks

### DIFF
--- a/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
@@ -8,6 +8,14 @@ metadata:
 spec:
   runInterval:  {{ .Values.check.daemonset.runInterval }}
   timeout: {{ .Values.check.daemonset.timeout }}
+  {{- if .Values.check.daemonset.extraAnnotations }}
+  extraAnnotations:
+{{- toYaml .Values.check.daemonset.extraAnnotations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.check.daemonset.extraLabels }}
+  extraLabels:
+{{- toYaml .Values.check.daemonset.extraLabels | nindent 4 }}
+  {{- end }}
   podSpec:
     {{- if .Values.check.daemonset.serviceAccountName }}
     serviceAccountName: {{ .Values.check.daemonset.serviceAccountName }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
@@ -8,6 +8,14 @@ metadata:
 spec:
   runInterval:  {{ .Values.check.deployment.runInterval }}
   timeout: {{ .Values.check.deployment.timeout }}
+  {{- if .Values.check.deployment.extraAnnotations }}
+  extraAnnotations:
+{{- toYaml .Values.check.deployment.extraAnnotations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.check.deployment.extraLabels }}
+  extraLabels:
+{{- toYaml .Values.check.deployment.extraLabels | nindent 4 }}
+  {{- end }}
   podSpec:
     {{- if .Values.securityContext.enabled }}
     securityContext:

--- a/deploy/helm/kuberhealthy/templates/khcheck-dns-external.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-dns-external.yaml
@@ -8,6 +8,14 @@ metadata:
 spec:
   runInterval: {{ .Values.check.dnsExternal.runInterval }}
   timeout: {{ .Values.check.dnsExternal.timeout }}
+  {{- if .Values.check.dnsExternal.extraAnnotations }}
+  extraAnnotations:
+{{- toYaml .Values.check.dnsExternal.extraAnnotations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.check.dnsExternal.extraLabels }}
+  extraLabels:
+{{- toYaml .Values.check.dnsExternal.extraLabels | nindent 4 }}
+  {{- end }}
   podSpec:
     {{- if .Values.securityContext.enabled }}
     securityContext:

--- a/deploy/helm/kuberhealthy/templates/khcheck-dns-internal.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-dns-internal.yaml
@@ -8,6 +8,14 @@ metadata:
 spec:
   runInterval: {{ .Values.check.dnsInternal.runInterval }}
   timeout: {{ .Values.check.dnsInternal.timeout }}
+  {{- if .Values.check.dnsInternal.extraAnnotations }}
+  extraAnnotations:
+{{- toYaml .Values.check.dnsInternal.extraAnnotations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.check.dnsInternal.extraLabels }}
+  extraLabels:
+{{- toYaml .Values.check.dnsInternal.extraLabels | nindent 4 }}
+  {{- end }}
   podSpec:
     {{- if .Values.securityContext.enabled }}
     securityContext:

--- a/deploy/helm/kuberhealthy/templates/khcheck-network-connection.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-network-connection.yaml
@@ -8,6 +8,14 @@ metadata:
 spec:
   runInterval:  {{ .Values.check.networkConnection.runInterval }}
   timeout: {{ .Values.check.networkConnection.timeout }}
+  {{- if .Values.check.networkConnection.extraAnnotations }}
+  extraAnnotations:
+{{- toYaml .Values.check.networkConnection.extraAnnotations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.check.networkConnection.extraLabels }}
+  extraLabels:
+{{- toYaml .Values.check.networkConnection.extraLabels | nindent 4 }}
+  {{- end }}
   podSpec:
     {{- if .Values.securityContext.seccompProfile }}
     securityContext:
@@ -54,4 +62,3 @@ spec:
 {{- toYaml .Values.check.networkConnection.tolerations | nindent 6 }}
     {{- end }}
 {{- end }}
-

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-restarts.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-restarts.yaml
@@ -7,6 +7,14 @@ metadata:
 spec:
   runInterval: {{ .Values.check.podRestarts.runInterval }}
   timeout: {{ .Values.check.podRestarts.timeout }}
+  {{- if .Values.check.podRestarts.extraAnnotations }}
+  extraAnnotations:
+{{- toYaml .Values.check.podRestarts.extraAnnotations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.check.podRestarts.extraLabels }}
+  extraLabels:
+{{- toYaml .Values.check.podRestarts.extraLabels | nindent 4 }}
+  {{- end }}
   podSpec:
     {{- if .Values.securityContext.enabled }}
     securityContext:

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
@@ -7,6 +7,14 @@ metadata:
 spec:
   runInterval: {{ .Values.check.podStatus.runInterval }}
   timeout: {{ .Values.check.podStatus.timeout }}
+  {{- if .Values.check.podStatus.extraAnnotations }}
+  extraAnnotations:
+{{- toYaml .Values.check.podStatus.extraAnnotations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.check.podStatus.extraLabels }}
+  extraLabels:
+{{- toYaml .Values.check.podStatus.extraLabels | nindent 4 }}
+  {{- end }}
   podSpec:
     {{- if .Values.securityContext.enabled }}
     securityContext:

--- a/deploy/helm/kuberhealthy/templates/khcheck-storage.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-storage.yaml
@@ -10,6 +10,14 @@ metadata:
 spec:
   runInterval: {{ $.Values.check.storage.runInterval }}
   timeout: {{ $.Values.check.storage.timeout }}
+  {{- if .Values.check.storage.extraAnnotations }}
+  extraAnnotations:
+{{- toYaml .Values.check.storage.extraAnnotations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.check.storage.extraLabels }}
+  extraLabels:
+{{- toYaml .Values.check.storage.extraLabels | nindent 4 }}
+  {{- end }}
   podSpec:
     {{- if $.Values.securityContext.enabled }}
     securityContext:

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -178,6 +178,8 @@ check:
       tag: v3.3.0
     extraEnvs: {}
     nodeSelector: {}
+    extraAnnotations: {}
+    extraLabels: {}
     tolerations:
     #- key: "key"
     #  operator: "Equal"
@@ -200,6 +202,8 @@ check:
       CHECK_DEPLOYMENT_ROLLING_UPDATE: "true"
       CHECK_SERVICE_ACCOUNT: "default"
     nodeSelector: {}
+    extraAnnotations: {}
+    extraLabels: {}
     tolerations:
     #- key: "key"
     #  operator: "Equal"
@@ -222,6 +226,8 @@ check:
     extraEnvs:
       HOSTNAME: "kubernetes.default"
     nodeSelector: {}
+    extraAnnotations: {}
+    extraLabels: {}
     tolerations:
     #- key: "key"
     #  operator: "Equal"
@@ -242,6 +248,8 @@ check:
     extraEnvs:
       HOSTNAME: "google.com"
     nodeSelector: {}
+    extraAnnotations: {}
+    extraLabels: {}
     tolerations:
     #- key: "key"
     #  operator: "Equal"
@@ -263,6 +271,8 @@ check:
     extraEnvs:
       MAX_FAILURES_ALLOWED: "10"
     nodeSelector: {}
+    extraAnnotations: {}
+    extraLabels: {}
     tolerations: []
     #- key: "key"
     #  operator: "Equal"
@@ -283,6 +293,8 @@ check:
     allNamespaces: false
     extraEnvs: {}
     nodeSelector: {}
+    extraAnnotations: {}
+    extraLabels: {}
     tolerations: []
     #- key: "key"
     #  operator: "Equal"
@@ -310,6 +322,8 @@ check:
       CHECK_STORAGE_IMAGE: bitnami/nginx:1.19
       CHECK_STORAGE_INIT_IMAGE: bitnami/nginx:1.19
     nodeSelector: {}
+    extraAnnotations: {}
+    extraLabels: {}
     tolerations: []
     #- key: "key"
     #  operator: "Equal"
@@ -330,6 +344,8 @@ check:
     extraEnvs:
       CONNECTION_TARGET: "tcp://github.com:443"
     nodeSelector: {}
+    extraAnnotations: {}
+    extraLabels: {}
     tolerations: []
     #- key: "key"
     #  operator: "Equal"


### PR DESCRIPTION
The [khcheck spec](https://github.com/kuberhealthy/kuberhealthy/blob/d826dcf97a8c035e157a40cec646b15c527bfb41/deploy/helm/kuberhealthy/crds/comcast.github.io_khchecks.yaml#L44-L51) accepts `extraAnnotations` and `extraLabels` to apply to the underlying pods, but these values are not exposed in the helm chart. This adds the values to the helm chart template, if they exist.

## Testing
examples of running `helm template .` before and after modifying `values.yaml` with `extraAnnotations` and `extraLabels`:

### Before:
```yaml
check:
  deployment:
    extraAnnotations: {}
    extraLabels: {}
```

```yaml
---
# Source: kuberhealthy/templates/khcheck-deployment.yaml
apiVersion: comcast.github.io/v1
kind: KuberhealthyCheck
metadata:
  name: deployment
  namespace: default
spec:
  runInterval:  10m
  timeout: 15m
  podSpec:
    securityContext:
      runAsUser: 999
      fsGroup: 999
    containers:
    - name: deployment
      image: "docker.io/kuberhealthy/deployment-check:v1.9.0"
      imagePullPolicy: IfNotPresent
      env:
        - name: CHECK_DEPLOYMENT_REPLICAS
          value: "4"
        - name: CHECK_DEPLOYMENT_ROLLING_UPDATE
          value: "true"
        - name: CHECK_SERVICE_ACCOUNT
          value: "default"
      resources:
        requests:
          cpu: 25m
          memory: 15Mi
        limits:
          cpu: 40m
      securityContext:
        runAsNonRoot: true
        allowPrivilegeEscalation: false
        readOnlyRootFilesystem: true
    restartPolicy: Never
    serviceAccountName: deployment-sa
    terminationGracePeriodSeconds: 60
```

### After
```yaml
check:
  deployment:
    extraAnnotations:
      annotation1: one
      annotation2: two
    extraLabels:
      label1: one
      label2: two
```

```yaml
---
# Source: kuberhealthy/templates/khcheck-deployment.yaml
apiVersion: comcast.github.io/v1
kind: KuberhealthyCheck
metadata:
  name: deployment
  namespace: default
spec:
  runInterval:  10m
  timeout: 15m
  extraAnnotations:
    annotation1: one
    annotation2: two
  extraLabels:
    label1: one
    label2: two
  podSpec:
    securityContext:
      runAsUser: 999
      fsGroup: 999
    containers:
    - name: deployment
      image: "docker.io/kuberhealthy/deployment-check:v1.9.0"
      imagePullPolicy: IfNotPresent
      env:
        - name: CHECK_DEPLOYMENT_REPLICAS
          value: "4"
        - name: CHECK_DEPLOYMENT_ROLLING_UPDATE
          value: "true"
        - name: CHECK_SERVICE_ACCOUNT
          value: "default"
      resources:
        requests:
          cpu: 25m
          memory: 15Mi
        limits:
          cpu: 40m
      securityContext:
        runAsNonRoot: true
        allowPrivilegeEscalation: false
        readOnlyRootFilesystem: true
    restartPolicy: Never
    serviceAccountName: deployment-sa
    terminationGracePeriodSeconds: 60
```