### PR TITLE
fix(metrics): ensure that durations are sanitized before parsing

### DIFF
--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -38,7 +38,7 @@ func promMetricName(config PromMetricsConfig, checkOrJob string, checkName strin
 	return metricName
 }
 
-//GenerateMetrics takes the state and returns it in the Prometheus format
+// GenerateMetrics takes the state and returns it in the Prometheus format
 func GenerateMetrics(state health.State, config PromMetricsConfig) string {
 	metricsOutput := ""
 	healthStatus := "0"
@@ -67,6 +67,9 @@ func GenerateMetrics(state health.State, config PromMetricsConfig) string {
 		metricName := promMetricName(config, "check", c, d.Namespace, checkStatus, d.Errors)
 		metricDurationName := fmt.Sprintf("kuberhealthy_check_duration_seconds{check=\"%s\",namespace=\"%s\"}", c, d.Namespace)
 		metricCheckState[metricName] = checkStatus
+
+		// sometimes the run duration
+		d.RunDuration = strings.Trim(d.RunDuration, "'\"")
 
 		// if runDuration hasn't been set yet, ie. pod never ran or failed to provision, set runDuration to 0
 		if d.RunDuration == "" {
@@ -128,7 +131,7 @@ func GenerateMetrics(state health.State, config PromMetricsConfig) string {
 	return metricsOutput
 }
 
-//ErrorStateMetrics is a Prometheus metric meant to show Kuberhealthy has error
+// ErrorStateMetrics is a Prometheus metric meant to show Kuberhealthy has error
 func ErrorStateMetrics(state health.State) string {
 	errorOutput := ""
 	errorOutput += "# HELP kuberhealthy_running Shows if kuberhealthy is running error free\n"


### PR DESCRIPTION
Clean the run duration, in case there was an issue with setting it within the CRD.

In some cases where checks or jobs fail, the state string can be improperly set. I was unable to narrow down the specific pattern or place where this is being improperly set (though it is on check execution error, for sure). Instead, cleaning the run duration before hand ensures that the duration is not malformed (e.g. `"'"` or `"\""`).