### PR TITLE
fix: template serviceaccount name

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -31,3 +31,4 @@
 - [Ajay Kalambur](https://github.com/kalamburajay)
 - [Lorenzo Setale](https://setale.me/)
 - [Rachel Sheikh](https://github.com/sheikhrachel)
+- [Kevin Nandu](https://github.com/kevin90n)

--- a/deploy/helm/kuberhealthy/templates/deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
             # Provide the name of the ConfigMap containing the files you want
             # to add to the container
             name: kuberhealthy
-      serviceAccountName: kuberhealthy
+      serviceAccountName: {{ template "kuberhealthy.name" . }}
       automountServiceAccountToken: true
       {{- if .Values.deployment.priorityClassName }}
       priorityClassName: {{ .Values.deployment.priorityClassName }}


### PR DESCRIPTION
Issue: The serviceaccount name remains static at "kuberhealthy" eventhough we can create serviceaccount with a different name using `nameOverride`. 

Basically when someone deploys Kuberhealthy with `nameOverride` flag, the deployment fails as it complains about non-existing serviceaccount reference. This PR fixes it.