### PR TITLE
Add resourceVersion=0 to Pod list operation for improved performance

### DIFF
--- a/cmd/daemonset-check/kube_api.go
+++ b/cmd/daemonset-check/kube_api.go
@@ -94,7 +94,8 @@ func listPods(ctx context.Context) (*v13.PodList, error) {
 	err := backoff.Retry(func() error {
 		var err error
 		podList, err = getPodClient().List(ctx, metav1.ListOptions{
-			LabelSelector: "kh-app=" + daemonSetName + ",source=kuberhealthy,khcheck=daemonset",
+			LabelSelector:   "kh-app=" + daemonSetName + ",source=kuberhealthy,khcheck=daemonset",
+			ResourceVersion: "0",
 		})
 		return err
 	}, exponentialBackoff)


### PR DESCRIPTION
### Summary
This PR modifies the Pod listing operation in Kuberhealthy to specify `resourceVersion=0`. This change aims to improve the efficiency of list requests and enhance the overall performance of the API server.

### Motivation
By specifying `resourceVersion=0`, we can:
- Reduce the load on the API server by potentially limiting the data returned during list operations.
- Ensure that clients retrieve the latest state of the Pods without needing to track versions, which can help avoid inconsistencies.

### Changes
- Updated the relevant code section to include `resourceVersion=0` in the list options.

### Testing
- Conducted tests to ensure that the listing functionality works as expected after the modification.

### Impact
This change is expected to improve performance, especially in environments with a high number of Pods.
