### PR TITLE
feat: Allow extraLabels and extraAnnotations to be configured per check

### DIFF
--- a/deploy/helm/kuberhealthy/Chart.yaml
+++ b/deploy/helm/kuberhealthy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kuberhealthy
 appVersion: v2.8.0-rc3
-version: 105
+version: 106
 home: https://kuberhealthy.github.io/kuberhealthy/
 description: "An operator for synthetic test and monitoring. Works great with Prometheus."
 type: application

--- a/deploy/helm/kuberhealthy/templates/_helpers.tpl
+++ b/deploy/helm/kuberhealthy/templates/_helpers.tpl
@@ -17,3 +17,16 @@ Return the appropriate apiVersion for RBAC APIs.
 {{- end -}}
 {{- end -}}
 
+{{- define "kuberhealthy.extraLabels" }}
+  {{- if . -}}
+  extraLabels:
+    {{- toYaml . | nindent 2 }}
+  {{- end -}}
+{{ end -}}
+
+{{- define "kuberhealthy.extraAnnotations" }}
+  {{- if . -}}
+  extraAnnotations:
+    {{- toYaml . | nindent 2 }}
+  {{- end -}}
+{{ end -}}

--- a/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
@@ -8,6 +8,14 @@ metadata:
 spec:
   runInterval:  {{ .Values.check.daemonset.runInterval }}
   timeout: {{ .Values.check.daemonset.timeout }}
+  {{- if .Values.check.daemonset.extraAnnotations }}
+  extraAnnotations:
+    {{- toYaml .Values.check.daemonset.extraAnnotations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.check.daemonset.extraLabels }}
+  extraLabels:
+    {{- toYaml .Values.check.daemonset.extraLabels | nindent 4 }}
+  {{- end }}
   podSpec:
     {{- if .Values.check.daemonset.serviceAccountName }}
     serviceAccountName: {{ .Values.check.daemonset.serviceAccountName }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
@@ -8,14 +8,8 @@ metadata:
 spec:
   runInterval:  {{ .Values.check.daemonset.runInterval }}
   timeout: {{ .Values.check.daemonset.timeout }}
-  {{- if .Values.check.daemonset.extraAnnotations }}
-  extraAnnotations:
-    {{- toYaml .Values.check.daemonset.extraAnnotations | nindent 4 }}
-  {{- end }}
-  {{- if .Values.check.daemonset.extraLabels }}
-  extraLabels:
-    {{- toYaml .Values.check.daemonset.extraLabels | nindent 4 }}
-  {{- end }}
+  {{- include "kuberhealthy.extraAnnotations" .Values.check.daemonset.extraAnnotations | nindent 2 }}
+  {{- include "kuberhealthy.extraLabels" .Values.check.daemonset.extraLabels | nindent 2 }}
   podSpec:
     {{- if .Values.check.daemonset.serviceAccountName }}
     serviceAccountName: {{ .Values.check.daemonset.serviceAccountName }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
@@ -8,14 +8,8 @@ metadata:
 spec:
   runInterval:  {{ .Values.check.deployment.runInterval }}
   timeout: {{ .Values.check.deployment.timeout }}
-  {{- if .Values.check.daemonset.extraAnnotations }}
-  extraAnnotations:
-    {{- toYaml .Values.check.daemonset.extraAnnotations | nindent 4 }}
-  {{- end }}
-  {{- if .Values.check.daemonset.extraLabels }}
-  extraLabels:
-    {{- toYaml .Values.check.daemonset.extraLabels | nindent 4 }}
-  {{- end }}
+  {{- include "kuberhealthy.extraAnnotations" .Values.check.deployment.extraAnnotations | nindent 2 }}
+  {{- include "kuberhealthy.extraLabels" .Values.check.deployment.extraLabels | nindent 2 }}
   podSpec:
     {{- if .Values.securityContext.enabled }}
     securityContext:

--- a/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
@@ -8,6 +8,14 @@ metadata:
 spec:
   runInterval:  {{ .Values.check.deployment.runInterval }}
   timeout: {{ .Values.check.deployment.timeout }}
+  {{- if .Values.check.daemonset.extraAnnotations }}
+  extraAnnotations:
+    {{- toYaml .Values.check.daemonset.extraAnnotations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.check.daemonset.extraLabels }}
+  extraLabels:
+    {{- toYaml .Values.check.daemonset.extraLabels | nindent 4 }}
+  {{- end }}
   podSpec:
     {{- if .Values.securityContext.enabled }}
     securityContext:

--- a/deploy/helm/kuberhealthy/templates/khcheck-dns-external.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-dns-external.yaml
@@ -8,6 +8,14 @@ metadata:
 spec:
   runInterval: {{ .Values.check.dnsExternal.runInterval }}
   timeout: {{ .Values.check.dnsExternal.timeout }}
+  {{- if .Values.check.daemonset.extraAnnotations }}
+  extraAnnotations:
+    {{- toYaml .Values.check.daemonset.extraAnnotations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.check.daemonset.extraLabels }}
+  extraLabels:
+    {{- toYaml .Values.check.daemonset.extraLabels | nindent 4 }}
+  {{- end }}
   podSpec:
     {{- if .Values.securityContext.enabled }}
     securityContext:

--- a/deploy/helm/kuberhealthy/templates/khcheck-dns-external.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-dns-external.yaml
@@ -8,14 +8,8 @@ metadata:
 spec:
   runInterval: {{ .Values.check.dnsExternal.runInterval }}
   timeout: {{ .Values.check.dnsExternal.timeout }}
-  {{- if .Values.check.daemonset.extraAnnotations }}
-  extraAnnotations:
-    {{- toYaml .Values.check.daemonset.extraAnnotations | nindent 4 }}
-  {{- end }}
-  {{- if .Values.check.daemonset.extraLabels }}
-  extraLabels:
-    {{- toYaml .Values.check.daemonset.extraLabels | nindent 4 }}
-  {{- end }}
+  {{- include "kuberhealthy.extraAnnotations" .Values.check.dnsExternal.extraAnnotations | nindent 2 }}
+  {{- include "kuberhealthy.extraLabels" .Values.check.dnsExternal.extraLabels | nindent 2 }}
   podSpec:
     {{- if .Values.securityContext.enabled }}
     securityContext:

--- a/deploy/helm/kuberhealthy/templates/khcheck-dns-internal.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-dns-internal.yaml
@@ -8,14 +8,8 @@ metadata:
 spec:
   runInterval: {{ .Values.check.dnsInternal.runInterval }}
   timeout: {{ .Values.check.dnsInternal.timeout }}
-  {{- if .Values.check.daemonset.extraAnnotations }}
-  extraAnnotations:
-    {{- toYaml .Values.check.daemonset.extraAnnotations | nindent 4 }}
-  {{- end }}
-  {{- if .Values.check.daemonset.extraLabels }}
-  extraLabels:
-    {{- toYaml .Values.check.daemonset.extraLabels | nindent 4 }}
-  {{- end }}
+  {{- include "kuberhealthy.extraAnnotations" .Values.check.dnsInternal.extraAnnotations | nindent 2 }}
+  {{- include "kuberhealthy.extraLabels" .Values.check.dnsInternal.extraLabels | nindent 2 }}
   podSpec:
     {{- if .Values.securityContext.enabled }}
     securityContext:

--- a/deploy/helm/kuberhealthy/templates/khcheck-dns-internal.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-dns-internal.yaml
@@ -8,6 +8,14 @@ metadata:
 spec:
   runInterval: {{ .Values.check.dnsInternal.runInterval }}
   timeout: {{ .Values.check.dnsInternal.timeout }}
+  {{- if .Values.check.daemonset.extraAnnotations }}
+  extraAnnotations:
+    {{- toYaml .Values.check.daemonset.extraAnnotations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.check.daemonset.extraLabels }}
+  extraLabels:
+    {{- toYaml .Values.check.daemonset.extraLabels | nindent 4 }}
+  {{- end }}
   podSpec:
     {{- if .Values.securityContext.enabled }}
     securityContext:

--- a/deploy/helm/kuberhealthy/templates/khcheck-network-connection.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-network-connection.yaml
@@ -8,14 +8,8 @@ metadata:
 spec:
   runInterval:  {{ .Values.check.networkConnection.runInterval }}
   timeout: {{ .Values.check.networkConnection.timeout }}
-  {{- if .Values.check.daemonset.extraAnnotations }}
-  extraAnnotations:
-    {{- toYaml .Values.check.daemonset.extraAnnotations | nindent 4 }}
-  {{- end }}
-  {{- if .Values.check.daemonset.extraLabels }}
-  extraLabels:
-    {{- toYaml .Values.check.daemonset.extraLabels | nindent 4 }}
-  {{- end }}
+  {{- include "kuberhealthy.extraAnnotations" .Values.check.networkConnection.extraAnnotations | nindent 2 }}
+  {{- include "kuberhealthy.extraLabels" .Values.check.networkConnection.extraLabels | nindent 2 }}
   podSpec:
     {{- if .Values.securityContext.seccompProfile }}
     securityContext:

--- a/deploy/helm/kuberhealthy/templates/khcheck-network-connection.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-network-connection.yaml
@@ -8,6 +8,14 @@ metadata:
 spec:
   runInterval:  {{ .Values.check.networkConnection.runInterval }}
   timeout: {{ .Values.check.networkConnection.timeout }}
+  {{- if .Values.check.daemonset.extraAnnotations }}
+  extraAnnotations:
+    {{- toYaml .Values.check.daemonset.extraAnnotations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.check.daemonset.extraLabels }}
+  extraLabels:
+    {{- toYaml .Values.check.daemonset.extraLabels | nindent 4 }}
+  {{- end }}
   podSpec:
     {{- if .Values.securityContext.seccompProfile }}
     securityContext:

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-restarts.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-restarts.yaml
@@ -7,14 +7,8 @@ metadata:
 spec:
   runInterval: {{ .Values.check.podRestarts.runInterval }}
   timeout: {{ .Values.check.podRestarts.timeout }}
-  {{- if .Values.check.daemonset.extraAnnotations }}
-  extraAnnotations:
-    {{- toYaml .Values.check.daemonset.extraAnnotations | nindent 4 }}
-  {{- end }}
-  {{- if .Values.check.daemonset.extraLabels }}
-  extraLabels:
-    {{- toYaml .Values.check.daemonset.extraLabels | nindent 4 }}
-  {{- end }}
+  {{- include "kuberhealthy.extraAnnotations" .Values.check.podRestarts.extraAnnotations | nindent 2 }}
+  {{- include "kuberhealthy.extraLabels" .Values.check.podRestarts.extraLabels | nindent 2 }}
   podSpec:
     {{- if .Values.securityContext.enabled }}
     securityContext:

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-restarts.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-restarts.yaml
@@ -7,6 +7,14 @@ metadata:
 spec:
   runInterval: {{ .Values.check.podRestarts.runInterval }}
   timeout: {{ .Values.check.podRestarts.timeout }}
+  {{- if .Values.check.daemonset.extraAnnotations }}
+  extraAnnotations:
+    {{- toYaml .Values.check.daemonset.extraAnnotations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.check.daemonset.extraLabels }}
+  extraLabels:
+    {{- toYaml .Values.check.daemonset.extraLabels | nindent 4 }}
+  {{- end }}
   podSpec:
     {{- if .Values.securityContext.enabled }}
     securityContext:

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
@@ -7,14 +7,8 @@ metadata:
 spec:
   runInterval: {{ .Values.check.podStatus.runInterval }}
   timeout: {{ .Values.check.podStatus.timeout }}
-  {{- if .Values.check.daemonset.extraAnnotations }}
-  extraAnnotations:
-    {{- toYaml .Values.check.daemonset.extraAnnotations | nindent 4 }}
-  {{- end }}
-  {{- if .Values.check.daemonset.extraLabels }}
-  extraLabels:
-    {{- toYaml .Values.check.daemonset.extraLabels | nindent 4 }}
-  {{- end }}
+  {{- include "kuberhealthy.extraAnnotations" .Values.check.podStatus.extraAnnotations | nindent 2 }}
+  {{- include "kuberhealthy.extraLabels" .Values.check.podStatus.extraLabels | nindent 2 }}
   podSpec:
     {{- if .Values.securityContext.enabled }}
     securityContext:

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
@@ -7,6 +7,14 @@ metadata:
 spec:
   runInterval: {{ .Values.check.podStatus.runInterval }}
   timeout: {{ .Values.check.podStatus.timeout }}
+  {{- if .Values.check.daemonset.extraAnnotations }}
+  extraAnnotations:
+    {{- toYaml .Values.check.daemonset.extraAnnotations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.check.daemonset.extraLabels }}
+  extraLabels:
+    {{- toYaml .Values.check.daemonset.extraLabels | nindent 4 }}
+  {{- end }}
   podSpec:
     {{- if .Values.securityContext.enabled }}
     securityContext:

--- a/deploy/helm/kuberhealthy/templates/khcheck-storage.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-storage.yaml
@@ -10,6 +10,14 @@ metadata:
 spec:
   runInterval: {{ $.Values.check.storage.runInterval }}
   timeout: {{ $.Values.check.storage.timeout }}
+  {{- if .Values.check.daemonset.extraAnnotations }}
+  extraAnnotations:
+    {{- toYaml .Values.check.daemonset.extraAnnotations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.check.daemonset.extraLabels }}
+  extraLabels:
+    {{- toYaml .Values.check.daemonset.extraLabels | nindent 4 }}
+  {{- end }}
   podSpec:
     {{- if $.Values.securityContext.enabled }}
     securityContext:

--- a/deploy/helm/kuberhealthy/templates/khcheck-storage.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-storage.yaml
@@ -10,14 +10,8 @@ metadata:
 spec:
   runInterval: {{ $.Values.check.storage.runInterval }}
   timeout: {{ $.Values.check.storage.timeout }}
-  {{- if .Values.check.daemonset.extraAnnotations }}
-  extraAnnotations:
-    {{- toYaml .Values.check.daemonset.extraAnnotations | nindent 4 }}
-  {{- end }}
-  {{- if .Values.check.daemonset.extraLabels }}
-  extraLabels:
-    {{- toYaml .Values.check.daemonset.extraLabels | nindent 4 }}
-  {{- end }}
+  {{- include "kuberhealthy.extraAnnotations" .Values.check.storage.extraAnnotations | nindent 2 }}
+  {{- include "kuberhealthy.extraLabels" .Values.check.storage.extraLabels | nindent 2 }}
   podSpec:
     {{- if $.Values.securityContext.enabled }}
     securityContext:

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -172,6 +172,8 @@ check:
     enabled: true
     runInterval: 15m
     timeout: 12m
+    extraAnnotations: {}
+    extraLabels: {}
     image:
       registry: docker.io
       repository: kuberhealthy/daemonset-check
@@ -191,6 +193,8 @@ check:
     enabled: true
     runInterval: 10m
     timeout: 15m
+    extraAnnotations: {}
+    extraLabels: {}
     image:
       registry: docker.io
       repository: kuberhealthy/deployment-check
@@ -215,6 +219,8 @@ check:
     enabled: true
     runInterval: 2m
     timeout: 15m
+    extraAnnotations: {}
+    extraLabels: {}
     image:
       registry: docker.io
       repository: kuberhealthy/dns-resolution-check
@@ -235,6 +241,8 @@ check:
     enabled: false
     runInterval: 2m
     timeout: 15m
+    extraAnnotations: {}
+    extraLabels: {}
     image:
       registry: docker.io
       repository: kuberhealthy/dns-resolution-check
@@ -255,6 +263,8 @@ check:
     enabled: false
     runInterval: 5m
     timeout: 10m
+    extraAnnotations: {}
+    extraLabels: {}
     image:
       registry: docker.io
       repository: kuberhealthy/pod-restarts-check
@@ -276,6 +286,8 @@ check:
     enabled: false
     runInterval: 5m
     timeout: 15m
+    extraAnnotations: {}
+    extraLabels: {}
     image:
       registry: docker.io
       repository: kuberhealthy/pod-status-check
@@ -302,6 +314,8 @@ check:
     storageClass: [""]
     runInterval: 5m
     timeout: 10m
+    extraAnnotations: {}
+    extraLabels: {}
     image:
       registry: docker.io
       repository: chrishirsch/kuberhealthy-storage-check
@@ -323,6 +337,8 @@ check:
     enabled: false
     runInterval: 30m
     timeout: 10m
+    extraAnnotations: {}
+    extraLabels: {}
     image:
       registry: docker.io
       repository: kuberhealthy/network-connection-check


### PR DESCRIPTION
## Description

Hey there!

We have been dealing with some errors in kuberhealthy due to the concurrent nature of kuberhealthy and karpenter, one fighting to consume resources and the other fighting to set them free. 

One possible way to deal with this is to not allow karpenter to disrupt kuberhealthy checks with annotation the annotation `karpenter.sh/do-not-evict: "true"`

According to my ~deep~ investigation, [both extraAnnotations and extraLabels are already supported by khchecks](https://github.com/kuberhealthy/kuberhealthy/blob/master/pkg/apis/khcheck/v1/types.go#L37-L39) so we just need to put them in the values and pass it to the checks 🚀

I'm not sure about the `version` change as I would always have a semver instead of a single integer but I'm not here to fix the world, right?

I rendered the chart locally and everything seems to work.