### PR TITLE
fix: securityContext for some built-in checks

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -31,3 +31,4 @@
 - [Ajay Kalambur](https://github.com/kalamburajay)
 - [Lorenzo Setale](https://setale.me/)
 - [Rachel Sheikh](https://github.com/sheikhrachel)
+- [Cesar Acuna](https://github.com/acunabit)

--- a/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-daemonset.yaml
@@ -59,8 +59,13 @@ spec:
           {{- end }}
         {{- if .Values.securityContext.enabled }}
         securityContext:
+          runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
           allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
           readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+          {{- if .Values.securityContext.capabilities }}
+          capabilities:
+            {{- toYaml .Values.securityContext.capabilities | nindent 12 }}
+          {{- end }}
         {{- end}}
     {{- if .Values.check.daemonset.nodeSelector }}
     nodeSelector:

--- a/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-deployment.yaml
@@ -53,6 +53,10 @@ spec:
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
         allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
         readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+        {{- if .Values.securityContext.capabilities }}
+        capabilities:
+          {{- toYaml .Values.securityContext.capabilities | nindent 12 }}
+        {{- end }}
 {{- end}}
     restartPolicy: Never
     {{- if .Values.check.deployment.nodeSelector }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-dns-external.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-dns-external.yaml
@@ -54,8 +54,13 @@ spec:
           {{- end }}
         {{- if .Values.securityContext.enabled }}
         securityContext:
+          runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
           allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
           readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+          {{- if .Values.securityContext.capabilities }}
+          capabilities:
+            {{- toYaml .Values.securityContext.capabilities | nindent 12 }}
+          {{- end }}
         {{- end }}
     {{- if .Values.check.dnsExternal.nodeSelector }}
     nodeSelector:

--- a/deploy/helm/kuberhealthy/templates/khcheck-dns-internal.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-dns-internal.yaml
@@ -57,6 +57,10 @@ spec:
           runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
           allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
           readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+          {{- if .Values.securityContext.capabilities }}
+          capabilities:
+            {{- toYaml .Values.securityContext.capabilities | nindent 12 }}
+          {{- end }}
         {{- end }}
     {{- if .Values.check.dnsInternal.nodeSelector }}
     nodeSelector:

--- a/deploy/helm/kuberhealthy/templates/khcheck-network-connection.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-network-connection.yaml
@@ -44,6 +44,15 @@ spec:
           memory: {{ .Values.check.networkConnection.resources.limits.memory }}
           {{- end }}
         {{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+        readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+        {{- if .Values.securityContext.capabilities }}
+        capabilities:
+          {{- toYaml .Values.securityContext.capabilities | nindent 12 }}
+        {{- end }}
+      {{- end }}
     restartPolicy: Never
     {{- if .Values.check.networkConnection.nodeSelector }}
     nodeSelector:

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-restarts.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-restarts.yaml
@@ -57,6 +57,10 @@ spec:
         securityContext:
           allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
           readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+          {{- if .Values.securityContext.capabilities }}
+          capabilities:
+            {{- toYaml .Values.securityContext.capabilities | nindent 12 }}
+          {{- end }}
         {{- end }}
     {{- if .Values.check.podRestarts.nodeSelector }}
     nodeSelector:

--- a/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-pod-status.yaml
@@ -59,6 +59,10 @@ spec:
         securityContext:
           allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
           readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+          {{- if .Values.securityContext.capabilities }}
+          capabilities:
+            {{- toYaml .Values.securityContext.capabilities | nindent 12 }}
+          {{- end }}
         {{- end }}
 
     {{- if .Values.check.podStatus.nodeSelector }}

--- a/deploy/helm/kuberhealthy/templates/khcheck-storage.yaml
+++ b/deploy/helm/kuberhealthy/templates/khcheck-storage.yaml
@@ -64,6 +64,10 @@ spec:
       securityContext:
         allowPrivilegeEscalation: {{ $.Values.securityContext.allowPrivilegeEscalation }}
         readOnlyRootFilesystem: {{ $.Values.securityContext.readOnlyRootFilesystem }}
+        {{- if $.Values.securityContext.capabilities }}
+        capabilities:
+          {{- toYaml $.Values.securityContext.capabilities | nindent 12 }}
+        {{- end }}
       {{- end }}
     restartPolicy: Never
     serviceAccountName: storage-khcheck

--- a/deploy/helm/kuberhealthy/values.yaml
+++ b/deploy/helm/kuberhealthy/values.yaml
@@ -147,7 +147,9 @@ securityContext:
   readOnlyRootFilesystem: true
   #seccompProfile:
   #  type: RuntimeDefault
-
+  #capabilities:
+  #  drop:
+  #  - ALL
 # When enabled kuberhealthy will create a PodSecurityPolicy, Role and Binding to match the specified securityContext
 # In case you use your own images for tests, you might need to add other PSPs as well on your own
 podSecurityPolicy:


### PR DESCRIPTION
This pull request introduces the following updates to the Kuberhealthy Helm chart:

- Support for securityContext.capabilities. Allows fine-grained control over container capabilities to improve security configurations.
- Addition of runAsNonRoot to the DaemonSet and DNS External Checks. runAsNonRoot is available in all the other checks.