### PR TITLE
fixes for network connection check timeout issues

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -31,3 +31,4 @@
 - [Ajay Kalambur](https://github.com/kalamburajay)
 - [Lorenzo Setale](https://setale.me/)
 - [Rachel Sheikh](https://github.com/sheikhrachel)
+- [Nihat Ciddi](https://github.com/nak0f)


### PR DESCRIPTION

Fixes #1283

- Remove select on ctx.Done() channel. As this is redundant with doneChan. Also causes race issue when specified Timeout is smaller than actual connection timeout. (timeout: 1m, connection timeouts after 75s)
- Bring back CONNECTIION_TIMEOUT environment var, with a default of 30s.
- Report failure in cases where connections to target expected to be unsuccessful.