### PR TITLE
Fixes for node checks

### DIFF
--- a/pkg/checks/external/nodeCheck/main_test.go
+++ b/pkg/checks/external/nodeCheck/main_test.go
@@ -2,6 +2,9 @@ package nodeCheck
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -14,10 +17,33 @@ func init() {
 }
 
 func TestWaitForKuberhealthyEndpointReady(t *testing.T) {
-	khEndpoint := "http://non.existent/"
+	// Test with a healthy target
+	tsHealthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Hello")
+	}))
+	defer tsHealthy.Close()
 	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
-	err := <-waitForKuberhealthyEndpointReady(ctx, khEndpoint)
+	err := <-waitForKuberhealthyEndpointReady(ctx, tsHealthy.URL)
+	if err != nil {
+		t.Error("Test failed for waitForKuberhealthyEndpointReady. Test target endpoint is not healthy. Err: ", err.Error())
+	}
+
+	// Test with a target not responding
+	khEndpoint := "http://non.existent/"
+	ctx, _ = context.WithTimeout(context.Background(), 10*time.Second)
+	err = <-waitForKuberhealthyEndpointReady(ctx, khEndpoint)
 	if err == nil {
-		t.Error("Negative test failed for waitForKuberhealthyEndpointReady")
+		t.Error("Negative test failed for waitForKuberhealthyEndpointReady. Test target endpoint was supposed to be unreachable")
+	}
+
+	// Test with a target responding a http error
+	tsInError := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}))
+	defer tsInError.Close()
+	ctx, _ = context.WithTimeout(context.Background(), 10*time.Second)
+	err = <-waitForKuberhealthyEndpointReady(ctx, tsInError.URL)
+	if err == nil {
+		t.Error("Negative test failed for waitForKuberhealthyEndpointReady. Test target endpoint was supposed to be not ready")
 	}
 }


### PR DESCRIPTION
PR adds below fixes in Kuberhealthy readiness checks:
- Check http response code in requests made to Kuberhealthy endpoint. This is for catching issues in where there are intermediate proxies between checker and Kuberhealthy, like an Istio sidecar proxy.
- Use health check path (/) in WaitForKuberhealthy() instead of reporting path. Reporting path (/externalCheckStatus) responds with http 400 to readiness checks as it expects report payloads from KHchecks.
- Introduce a default http timeout in waitForKuberhealthyEndpointReady() in order to prevent http requests blocking the check longer than the context timeout.
- Add negative test to cover failure cases mentioned above