### PR TITLE
Add basic auth option for image pull check for private repositories

### DIFF
--- a/cmd/image-download-check/README.md
+++ b/cmd/image-download-check/README.md
@@ -1,5 +1,5 @@
 ## Image Download Check
-The `Image Download Check` pulls images from a specified registry set by env `FULL_IMAGE_URL` and evaluates if the actual pull duration time exceeded the configured timeout limit set by env `TIMEOUT_LIMIT`. If the pull duration exceeds the configured timeout, the check fails and is reported to Kuberhealthy servers.
+The `Image Download Check` pulls images from a specified registry set by env `FULL_IMAGE_URL` and evaluates if the actual pull duration time exceeded the configured timeout limit set by env `TIMEOUT_LIMIT`. If the pull duration exceeds the configured timeout, the check fails and is reported to Kuberhealthy servers. If the registry requires authentication, then set the `LOGIN_REQUIRED` environment variable to `true` and provide the username and password using `REGISTRY_USERNAME` and `REGISTRY_PASSWORD` environment variables.
 
 #### Example Image Download Check Kubernetes Spec
 
@@ -22,6 +22,12 @@ spec:
             value: "nginx:1.21"   #### example: docker pull nginx:1.21
           - name: TIMEOUT_LIMIT
             value: "180s"         #### in seconds
+          - name: LOGIN_REQUIRED
+            value: "true"        #### set to true if the registry requires login
+          - name: REGISTRY_USERNAME
+            value: "username"    #### registry username
+          - name: REGISTRY_PASSWORD
+            value: "password"    #### registry password
         resources:
           requests:
             cpu: 15m


### PR DESCRIPTION
Hello kuberhealthy team!
I have an on premise use case where I want to use Kuberhealthy checks to monitor various parts of the infrastructure setup. One problem that I'm facing is that the image pull checker doesn't allow configuration for private repositories. I know that in cloud setups you can assign identities and gain access to container registry service, but for on premise setups it's easier to just provide the credentials to the check.
I prepared this small PR to include a flag and 2 new parameters to specifiy if you want to set basic auth login to the target registry and to provide the username / password.

Thanks.
Ghita Bot.