### PR TITLE
Add test for check report handler

### DIFF
--- a/cmd/kuberhealthy/check_report_handler_test.go
+++ b/cmd/kuberhealthy/check_report_handler_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	kuberhealthycheckv2 "github.com/kuberhealthy/crds/api/v2"
+	"github.com/kuberhealthy/kuberhealthy/v3/internal/health"
+)
+
+// TestCheckReportHandler validates the check report handler logic.
+func TestCheckReportHandler(t *testing.T) {
+	// preserve original function implementations
+	origValidateHeader := validateUsingRequestHeaderFunc
+	origValidateIP := validatePodReportBySourceIPFunc
+	origStore := storeCheckStateFunc
+	defer func() {
+		validateUsingRequestHeaderFunc = origValidateHeader
+		validatePodReportBySourceIPFunc = origValidateIP
+		storeCheckStateFunc = origStore
+	}()
+
+	t.Run("valid report", func(t *testing.T) {
+		validateUsingRequestHeaderFunc = func(ctx context.Context, r *http.Request) (PodReportInfo, bool, error) {
+			return PodReportInfo{Name: "my-check", Namespace: "my-namespace", UUID: "abc"}, true, nil
+		}
+		validatePodReportBySourceIPFunc = func(ctx context.Context, r *http.Request) (PodReportInfo, error) {
+			t.Fatalf("unexpected call to validatePodReportBySourceIPFunc")
+			return PodReportInfo{}, nil
+		}
+		var storedName, storedNamespace string
+		var storedDetails *kuberhealthycheckv2.KuberhealthyCheckStatus
+		storeCheckStateFunc = func(name, namespace string, details *kuberhealthycheckv2.KuberhealthyCheckStatus) error {
+			storedName = name
+			storedNamespace = namespace
+			storedDetails = details
+			return nil
+		}
+
+		report := health.Report{OK: true}
+		b, err := json.Marshal(report)
+		if err != nil {
+			t.Fatalf("failed to marshal report: %v", err)
+		}
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(b))
+		rr := httptest.NewRecorder()
+
+		if err := checkReportHandler(rr, req); err != nil {
+			t.Fatalf("handler returned error: %v", err)
+		}
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected status %d, got %d", http.StatusOK, rr.Code)
+		}
+		if storedName != "my-check" || storedNamespace != "my-namespace" {
+			t.Fatalf("storeCheckState called with unexpected values: %s %s", storedName, storedNamespace)
+		}
+		if storedDetails == nil || !storedDetails.OK {
+			t.Fatalf("storeCheckState received incorrect details: %+v", storedDetails)
+		}
+	})
+
+	t.Run("missing error when not OK", func(t *testing.T) {
+		validateUsingRequestHeaderFunc = func(ctx context.Context, r *http.Request) (PodReportInfo, bool, error) {
+			return PodReportInfo{Name: "my-check", Namespace: "my-namespace", UUID: "abc"}, true, nil
+		}
+		validatePodReportBySourceIPFunc = func(ctx context.Context, r *http.Request) (PodReportInfo, error) {
+			t.Fatalf("unexpected call to validatePodReportBySourceIPFunc")
+			return PodReportInfo{}, nil
+		}
+		storeCalled := false
+		storeCheckStateFunc = func(string, string, *kuberhealthycheckv2.KuberhealthyCheckStatus) error {
+			storeCalled = true
+			return nil
+		}
+
+		report := health.Report{OK: false}
+		b, err := json.Marshal(report)
+		if err != nil {
+			t.Fatalf("failed to marshal report: %v", err)
+		}
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(b))
+		rr := httptest.NewRecorder()
+
+		if err := checkReportHandler(rr, req); err != nil {
+			t.Fatalf("handler returned error: %v", err)
+		}
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
+		}
+		if storeCalled {
+			t.Fatalf("storeCheckState should not be called on invalid report")
+		}
+	})
+}

--- a/cmd/kuberhealthy/webserver.go
+++ b/cmd/kuberhealthy/webserver.go
@@ -81,6 +81,13 @@ type PodReportInfo struct {
 	Namespace string
 }
 
+// function variables allow tests to stub dependencies
+var (
+	validateUsingRequestHeaderFunc  = validateUsingRequestHeader
+	validatePodReportBySourceIPFunc = validatePodReportBySourceIP
+	storeCheckStateFunc             = storeCheckState
+)
+
 // validateExternalRequest calls the Kubernetes API to fetch details about a pod using a selector string.
 // It validates that the pod is allowed to report the status of a check. The pod is also expected
 // to have the environment variable KH_CHECK_NAME
@@ -234,7 +241,7 @@ func checkReportHandler(w http.ResponseWriter, r *http.Request) error {
 	// Validate request using the kh-run-uuid header. If the header doesn't exist, or there's an error with validation,
 	// validate using the pod's remote IP.
 	log.Println("webserver:", requestID, "validating external check status report from its reporting kuberhealthy run uuid:", r.Header.Get("kh-run-uuid"))
-	podReport, reportValidated, err := validateUsingRequestHeader(ctx, r)
+	podReport, reportValidated, err := validateUsingRequestHeaderFunc(ctx, r)
 	if err != nil {
 		log.Println("webserver:", requestID, "Failed to look up pod by its kh-run-uuid header:", r.Header.Get("kh-run-uuid"), err)
 	}
@@ -242,7 +249,7 @@ func checkReportHandler(w http.ResponseWriter, r *http.Request) error {
 	// If the check uuid header is missing, attempt to validate using calling pod's source IP
 	if !reportValidated {
 		log.Println("webserver:", requestID, "validating external check status report from the pod's remote IP:", r.RemoteAddr)
-		podReport, err = validatePodReportBySourceIP(ctx, r)
+		podReport, err = validatePodReportBySourceIPFunc(ctx, r)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			log.Println("webserver:", requestID, "Failed to look up pod by its IP:", r.RemoteAddr, err)
@@ -304,7 +311,7 @@ func checkReportHandler(w http.ResponseWriter, r *http.Request) error {
 
 	// since the check is validated, we can proceed to update the status now
 	log.Println("webserver:", requestID, "Setting check with name", podReport.Name, "in namespace", podReport.Namespace, "to 'OK' state:", details.OK, "uuid", details.CurrentUUID)
-	err = storeCheckState(podReport.Name, podReport.Namespace, details)
+	err = storeCheckStateFunc(podReport.Name, podReport.Namespace, details)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		log.Println("webserver:", requestID, "failed to store check state for %s: %w", podReport.Name, err)


### PR DESCRIPTION
## Summary
- allow stubbing of report validation and storage functions
- cover check report handler success and failure cases with new tests

## Testing
- `go test -v ./cmd/kuberhealthy -run TestCheckReportHandler -count=1` *(fails: command hung, likely due to missing module dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ef864a648323becb81a835b31557