### PR TITLE
Add Kubernetes manifest validation workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,14 +1,19 @@
 name: End to End Kuberhealthy Test
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - master
+      - release/*
+      - actions # for testing this build spec
+      - v3
   push:
     branches:
-    - master
-    - release/*
-    - actions # for testing this build spec
+      - master
+      - release/*
+      - actions # for testing this build spec
+      - v3
 
 jobs:
   build:

--- a/.github/workflows/validate-kustomize.yml
+++ b/.github/workflows/validate-kustomize.yml
@@ -1,0 +1,43 @@
+name: Validate Kubernetes Manifests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+      - release/*
+      - actions
+      - v3
+    paths:
+      - 'deploy/**'
+  push:
+    branches:
+      - master
+      - release/*
+      - actions
+      - v3
+    paths:
+      - 'deploy/**'
+
+jobs:
+  kustomize:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Validate kustomize specs
+      uses: stefanprodan/kube-tools@v1
+      with:
+        kubectl: 1.29.2
+        kustomize: 5.4.1
+        command: |
+          set -e
+          echo "Checking kustomizations"
+          find deploy -type f \( -name kustomization.yaml -o -name kustomization.yml \) | while read k; do
+            echo "Validating ${k}"
+            dir=$(dirname "$k")
+            kustomize build "$dir" | kubectl apply --dry-run=client --validate=true -f -
+          done
+          echo "Validating flat manifests"
+          find deploy -maxdepth 1 -type f -name '*.yaml' | while read f; do
+            kubectl apply --dry-run=client --validate=true -f "$f"
+          done


### PR DESCRIPTION
## Summary
- run kustomize validation workflow manually or on changes to master, release/*, actions, or v3 branches
- run e2e workflow manually or on changes to master, release/*, actions, or v3 branches

## Testing
- `go test ./...` *(fails: DNS resolution check nil pointer, image-download-check build error, missing Kubernetes config)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f84d883c8323af952c28ad516505