### PR TITLE
Expose metrics for Prometheus

### DIFF
--- a/cmd/kuberhealthy/main.go
+++ b/cmd/kuberhealthy/main.go
@@ -97,6 +97,10 @@ func initConfig() error {
 		log.Println("WARNING: Failed to read configuration file from disk:", err)
 	}
 
+	if len(GlobalConfig.ListenAddress) == 0 {
+		GlobalConfig.ListenAddress = ":8080"
+	}
+
 	// Set the target namespace to whatever the KH_TARGET_NAMESPACE env var is.  Defaults to blank, which means all, if unset.
 	GlobalConfig.TargetNamespace = os.Getenv("KH_TARGET_NAMESPACE")
 

--- a/cmd/kuberhealthy/metrics_handler_test.go
+++ b/cmd/kuberhealthy/metrics_handler_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	kuberhealthycheckv2 "github.com/kuberhealthy/crds/api/v2"
+	"github.com/kuberhealthy/kuberhealthy/v3/internal/controller"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestPrometheusMetricsEndpoint(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := kuberhealthycheckv2.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add scheme: %v", err)
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(s).Build()
+	KHController = &controller.KuberhealthyCheckReconciler{Client: fakeClient}
+	GlobalConfig = &Config{}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/metrics" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := prometheusMetricsHandler(w, r); err != nil {
+			t.Fatalf("handler error: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/metrics")
+	if err != nil {
+		t.Fatalf("failed to GET metrics: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200 got %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed reading body: %v", err)
+	}
+	if !strings.Contains(string(body), "kuberhealthy_running") {
+		t.Fatalf("unexpected metrics body: %s", string(body))
+	}
+}

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -12,6 +12,10 @@ spec:
     metadata:
       labels:
         app: kuberhealthy
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: /metrics
     spec:
       serviceAccountName: kuberhealthy
       containers:

--- a/deploy/base/service.yaml
+++ b/deploy/base/service.yaml
@@ -3,6 +3,10 @@ kind: Service
 metadata:
   name: kuberhealthy
   namespace: kuberhealthy
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8080"
+    prometheus.io/path: /metrics
 spec:
   selector:
     app: kuberhealthy


### PR DESCRIPTION
## Summary
- expose Prometheus metrics and cluster check status
- annotate deployment and service for Prometheus scraping
- add test for metrics endpoint

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a7feac93888323b71e12106ff72c4d