### PR TITLE
refactor: replace configmap with env vars

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -15,9 +15,9 @@ test: # Run tests locally
 	go test -v cmd/...
 
 run: # Run Kuberhealthy locally
-	cd cmd/kuberhealthy && \
-	go build -v && \
-	KH_EXTERNAL_REPORTING_URL=localhost:8006 POD_NAMESPACE=kuberhealthy POD_NAME="kuberhealthy-test" ./kuberhealthy --debug --config ./test/test-config.yaml
+        cd cmd/kuberhealthy && \
+        go build -v && \
+        KH_EXTERNAL_REPORTING_URL=localhost:8006 POD_NAMESPACE=kuberhealthy POD_NAME="kuberhealthy-test" ./kuberhealthy --debug
 
 kustomize: # Apply Kubernetes specs from deploy/ directory
 	kustomize build deploy/ | kubectl apply -f -

--- a/README.md
+++ b/README.md
@@ -46,11 +46,9 @@ kustomize build "github.com/kuberhealthy/kuberhealthy/deploy?ref=<tag>" | kubect
 After installation, Kuberhealthy will only be available from within the cluster (`Type: ClusterIP`) at the service URL `kuberhealthy.kuberhealthy`.  To expose Kuberhealthy to clients outside of the cluster, you **must** edit the service `kuberhealthy` and set `Type: LoadBalancer` or otherwise expose the service yourself.
 
 
-#### Edit Configuration Settings
+#### Configure Environment Variables
 
-You can edit the Kuberhealthy configmap as well and it will be automatically reloaded by Kuberhealthy.  All configmap options are set to their defaults to make configuration easy.
-
-`kubectl edit -n kuberhealthy configmap kuberhealthy`
+Kuberhealthy is configured entirely with environment variables. The deployment manifest in this repository includes default values for all options. Modify the container's environment variables to tune Kuberhealthy for your cluster.
 
 #### See Configured Checks
 
@@ -59,10 +57,7 @@ You can see checks that are configured with `kubectl -n kuberhealthy get khcheck
 
 ### Further Configuration
 
-
-To configure Kuberhealthy after installation, see the [configuration documentation](https://github.com/kuberhealthy/kuberhealthy/blob/master/docs/CONFIGURATION.md).
-
-More installation options, including flat YAML manifests for the current v3 branch, are available in the [/deploy](/deploy) directory.
+A full list of flags and environment variables is available in [docs/FLAGS.md](docs/FLAGS.md). More installation options, including flat YAML manifests for the current v3 branch, are available in the [/deploy](/deploy) directory.
 
 ## Visualized
 

--- a/cmd/kuberhealthy/README.md
+++ b/cmd/kuberhealthy/README.md
@@ -11,6 +11,19 @@ If you don't have `just` or `podman` installed, install them.
 
 # Environment Variables
 ```
+KH_LISTEN_ADDRESS=":8080"
+KH_LOG_LEVEL="info"
+KH_MAX_JOB_AGE=""
+KH_MAX_CHECK_POD_AGE=""
+KH_MAX_COMPLETED_POD_COUNT="0"
+KH_MAX_ERROR_POD_COUNT="0"
+KH_PROM_SUPPRESS_ERROR_LABEL="false"
+KH_PROM_ERROR_LABEL_MAX_LENGTH="0"
 KH_TARGET_NAMESPACE="kuberhealthy"
+KH_DEFAULT_RUN_INTERVAL="10m"
 KH_CHECK_REPORT_HOSTNAME="kuberhealthy.kuberhealthy.svc.cluster.local"
+KH_TERMINATION_GRACE_PERIOD="5m"
+KH_DEFAULT_CHECK_TIMEOUT="5m"
+KH_DEBUG_MODE="false"
+KH_DEFAULT_NAMESPACE="kuberhealthy"
 ```

--- a/cmd/kuberhealthy/config_test.go
+++ b/cmd/kuberhealthy/config_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLoadFromEnv(t *testing.T) {
+	t.Setenv("KH_LISTEN_ADDRESS", "127.0.0.1:9000")
+	t.Setenv("KH_LOG_LEVEL", "debug")
+	t.Setenv("KH_MAX_JOB_AGE", "30m")
+	t.Setenv("KH_MAX_CHECK_POD_AGE", "15m")
+	t.Setenv("KH_MAX_COMPLETED_POD_COUNT", "5")
+	t.Setenv("KH_MAX_ERROR_POD_COUNT", "2")
+	t.Setenv("KH_PROM_SUPPRESS_ERROR_LABEL", "true")
+	t.Setenv("KH_PROM_ERROR_LABEL_MAX_LENGTH", "20")
+	t.Setenv("KH_TARGET_NAMESPACE", "testing")
+	t.Setenv("KH_DEFAULT_RUN_INTERVAL", "3m")
+	t.Setenv("KH_CHECK_REPORT_HOSTNAME", "example.com")
+	t.Setenv("KH_TERMINATION_GRACE_PERIOD", "30s")
+	t.Setenv("KH_DEFAULT_CHECK_TIMEOUT", "1m")
+	t.Setenv("KH_DEBUG_MODE", "true")
+	t.Setenv("KH_DEFAULT_NAMESPACE", "fallback")
+
+	cfg := New()
+	if err := cfg.LoadFromEnv(); err != nil {
+		t.Fatalf("LoadFromEnv returned error: %v", err)
+	}
+
+	if cfg.ListenAddress != "127.0.0.1:9000" {
+		t.Errorf("ListenAddress parsed incorrectly: %s", cfg.ListenAddress)
+	}
+	if cfg.LogLevel != "debug" {
+		t.Errorf("LogLevel parsed incorrectly: %s", cfg.LogLevel)
+	}
+	if cfg.MaxKHJobAge != 30*time.Minute {
+		t.Errorf("MaxKHJobAge parsed incorrectly: %v", cfg.MaxKHJobAge)
+	}
+	if cfg.MaxCheckPodAge != 15*time.Minute {
+		t.Errorf("MaxCheckPodAge parsed incorrectly: %v", cfg.MaxCheckPodAge)
+	}
+	if cfg.MaxCompletedPodCount != 5 {
+		t.Errorf("MaxCompletedPodCount parsed incorrectly: %d", cfg.MaxCompletedPodCount)
+	}
+	if cfg.MaxErrorPodCount != 2 {
+		t.Errorf("MaxErrorPodCount parsed incorrectly: %d", cfg.MaxErrorPodCount)
+	}
+	if !cfg.PromMetricsConfig.SuppressErrorLabel {
+		t.Errorf("PromMetricsConfig.SuppressErrorLabel parsed incorrectly")
+	}
+	if cfg.PromMetricsConfig.ErrorLabelMaxLength != 20 {
+		t.Errorf("PromMetricsConfig.ErrorLabelMaxLength parsed incorrectly: %d", cfg.PromMetricsConfig.ErrorLabelMaxLength)
+	}
+	if cfg.TargetNamespace != "testing" {
+		t.Errorf("TargetNamespace parsed incorrectly: %s", cfg.TargetNamespace)
+	}
+	if cfg.DefaultRunInterval != 3*time.Minute {
+		t.Errorf("DefaultRunInterval parsed incorrectly: %v", cfg.DefaultRunInterval)
+	}
+	if cfg.ReportingURL() != "http://example.com/check" {
+		t.Errorf("ReportingURL parsed incorrectly: %s", cfg.ReportingURL())
+	}
+	if cfg.TerminationGracePeriodSeconds != 30*time.Second {
+		t.Errorf("TerminationGracePeriodSeconds parsed incorrectly: %v", cfg.TerminationGracePeriodSeconds)
+	}
+	if cfg.DefaultCheckTimeout != time.Minute {
+		t.Errorf("DefaultCheckTimeout parsed incorrectly: %v", cfg.DefaultCheckTimeout)
+	}
+	if !cfg.DebugMode {
+		t.Errorf("DebugMode parsed incorrectly: %v", cfg.DebugMode)
+	}
+	if cfg.DefaultNamespace != "fallback" {
+		t.Errorf("DefaultNamespace parsed incorrectly: %s", cfg.DefaultNamespace)
+	}
+}
+
+func TestLoadFromEnvInvalid(t *testing.T) {
+	t.Setenv("KH_MAX_JOB_AGE", "not-a-duration")
+	cfg := New()
+	if err := cfg.LoadFromEnv(); err == nil {
+		t.Fatalf("expected error for invalid duration")
+	}
+}

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -23,11 +23,37 @@ spec:
         image: docker.io/kuberhealthy/kuberhealthy:localdev
         imagePullPolicy: Never
         env:
-        - name: TARGET_NAMESPACE
+        - name: KH_LISTEN_ADDRESS
+          value: ":8080"
+        - name: KH_LOG_LEVEL
+          value: "info"
+        - name: KH_MAX_JOB_AGE
+          value: ""
+        - name: KH_MAX_CHECK_POD_AGE
+          value: ""
+        - name: KH_MAX_COMPLETED_POD_COUNT
+          value: "0"
+        - name: KH_MAX_ERROR_POD_COUNT
+          value: "0"
+        - name: KH_PROM_SUPPRESS_ERROR_LABEL
+          value: "false"
+        - name: KH_PROM_ERROR_LABEL_MAX_LENGTH
+          value: "0"
+        - name: KH_TARGET_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KH_DEFAULT_RUN_INTERVAL
+          value: "10m"
         - name: KH_CHECK_REPORT_HOSTNAME
           value: "kuberhealthy.kuberhealthy.svc.cluster.local"
+        - name: KH_TERMINATION_GRACE_PERIOD
+          value: "5m"
+        - name: KH_DEFAULT_CHECK_TIMEOUT
+          value: "5m"
+        - name: KH_DEBUG_MODE
+          value: "false"
+        - name: KH_DEFAULT_NAMESPACE
+          value: "kuberhealthy"
         ports:
         - containerPort: 8080

--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -1,10 +1,27 @@
-Available flags for use in Kuberhealthy
-
-For more configuration options, see the [configmap](https://github.com/kuberhealthy/kuberhealthy/blob/master/docs/CONFIGURATION.md) documentation
+Available flags and environment variables for use in Kuberhealthy
 
 # Flags
 
-| Flag       | Description                           | Optional | Default              |
-| ---------- | ------------------------------------- | -------- | -------------------- |
-| `--config` | Absolute path to a kube config file.  | Yes      | `$HOME/.kube/config` |
-| `--debug`  | Bool to enable/disable debug logging. | Yes      | `False`              |
+| Flag      | Description                           | Optional | Default |
+| --------- | ------------------------------------- | -------- | ------- |
+| `--debug` | Bool to enable/disable debug logging. | Yes      | `False` |
+
+# Environment Variables
+
+| Variable | Description | Default |
+| -------- | ----------- | ------- |
+| `KH_LISTEN_ADDRESS` | Address for the web server | `:8080` |
+| `KH_LOG_LEVEL` | Log level (trace, debug, info, warn, error, fatal, panic) | `info` |
+| `KH_MAX_JOB_AGE` | Maximum age for check jobs before cleanup | unset |
+| `KH_MAX_CHECK_POD_AGE` | Maximum age for check pods before cleanup | unset |
+| `KH_MAX_COMPLETED_POD_COUNT` | Number of completed pods to retain | `0` |
+| `KH_MAX_ERROR_POD_COUNT` | Number of error pods to retain | `0` |
+| `KH_PROM_SUPPRESS_ERROR_LABEL` | Omit error label in Prometheus metrics | `false` |
+| `KH_PROM_ERROR_LABEL_MAX_LENGTH` | Maximum length for Prometheus error label | `0` |
+| `KH_TARGET_NAMESPACE` | Namespace Kuberhealthy operates in (blank for all) | <pod namespace> |
+| `KH_DEFAULT_RUN_INTERVAL` | Default check run interval | `10m` |
+| `KH_CHECK_REPORT_HOSTNAME` | Hostname used for check reports | `kuberhealthy.kuberhealthy.svc.cluster.local` |
+| `KH_TERMINATION_GRACE_PERIOD` | Shutdown grace period | `5m` |
+| `KH_DEFAULT_CHECK_TIMEOUT` | Default timeout for checks | `5m` |
+| `KH_DEBUG_MODE` | Enable debug mode | `false` |
+| `KH_DEFAULT_NAMESPACE` | Fallback namespace if detection fails | `kuberhealthy` |


### PR DESCRIPTION
## Summary
- drop configmap based configuration and watch loops
- load all Kuberhealthy settings from environment variables
- document and template default environment variables
- add tests for env var parsing

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a80c1b6b148323a93761d754855c16