### PR TITLE
Add cloud load balancer overlays and port-forward docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,32 @@ If you prefer to review the manifests first, run:
 kustomize build "github.com/kuberhealthy/kuberhealthy/deploy?ref=<tag>" | kubectl apply -f -
 ```
 
+After installation you can reach the Kuberhealthy graphical status page locally with:
+
+```sh
+kubectl -n kuberhealthy port-forward svc/kuberhealthy 8080:8080
+```
+
+Then open [http://localhost:8080](http://localhost:8080) in your browser.
+
 #### Configure Service
 
 After installation, Kuberhealthy will only be available from within the cluster (`Type: ClusterIP`) at the service URL `kuberhealthy.kuberhealthy`.  To expose Kuberhealthy to clients outside of the cluster, you **must** edit the service `kuberhealthy` and set `Type: LoadBalancer` or otherwise expose the service yourself.
+
+Optional kustomize overlays are available to automatically expose the service:
+
+- **AWS EKS with AWS Load Balancer Controller**
+  ```sh
+  kubectl apply -k "github.com/kuberhealthy/kuberhealthy/deploy/aws-lb-controller?ref=<tag>"
+  ```
+- **GCP GKE with GKE load balancer controller**
+  ```sh
+  kubectl apply -k "github.com/kuberhealthy/kuberhealthy/deploy/gcp-lb-controller?ref=<tag>"
+  ```
+- **Generic ingress controller**
+  ```sh
+  kubectl apply -k "github.com/kuberhealthy/kuberhealthy/deploy/ingress?ref=<tag>"
+  ```
 
 
 #### Edit Configuration Settings

--- a/deploy/aws-lb-controller/kustomization.yaml
+++ b/deploy/aws-lb-controller/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patchesStrategicMerge:
+  - service-patch.yaml

--- a/deploy/aws-lb-controller/service-patch.yaml
+++ b/deploy/aws-lb-controller/service-patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kuberhealthy
+  namespace: kuberhealthy
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: "external"
+spec:
+  type: LoadBalancer

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+  - kuberhealthycheck.yaml
+  - clusterrole.yaml
+  - serviceaccount.yaml

--- a/deploy/gcp-lb-controller/kustomization.yaml
+++ b/deploy/gcp-lb-controller/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patchesStrategicMerge:
+  - service-patch.yaml

--- a/deploy/gcp-lb-controller/service-patch.yaml
+++ b/deploy/gcp-lb-controller/service-patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kuberhealthy
+  namespace: kuberhealthy
+  annotations:
+    cloud.google.com/load-balancer-type: "External"
+spec:
+  type: LoadBalancer

--- a/deploy/ingress/ingress.yaml
+++ b/deploy/ingress/ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kuberhealthy
+  namespace: kuberhealthy
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: kuberhealthy
+            port:
+              number: 8080

--- a/deploy/ingress/kustomization.yaml
+++ b/deploy/ingress/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - ingress.yaml


### PR DESCRIPTION
## Summary
- document port-forwarding to Kuberhealthy UI and how to expose it via optional overlays
- add kustomize overlays for AWS and GCP load balancer controllers and a generic ingress
- provide base kustomization to support overlays

## Testing
- `kustomize build deploy/aws-lb-controller`
- `kustomize build deploy/gcp-lb-controller`
- `kustomize build deploy/ingress`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a80d41c82c8323b056f845f383ebd4