### PR TITLE
Add workflow to build multi-arch container images

### DIFF
--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -1,0 +1,40 @@
+name: Build and Push Image
+
+on:
+  push:
+    paths:
+      - 'cmd/**'
+      - 'internal/**'
+      - 'pkg/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set image tag
+        run: |
+          BRANCH_NAME="${GITHUB_REF_NAME//\//-}"
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          echo "IMAGE_TAG=${BRANCH_NAME}-${SHORT_SHA}" >> $GITHUB_ENV
+      - name: Build and Push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${{ env.IMAGE_TAG }}


### PR DESCRIPTION
## Summary
- build and push docker images to GHCR when code under cmd/, internal/, or pkg/ changes
- support multi-arch builds for amd64 and arm64
- tag images with the sanitized branch name and short commit sha

## Testing
- `timeout 30 go test ./...` *(fails: command terminated without output)*

------
https://chatgpt.com/codex/tasks/task_e_68a811b624b88323941b8a30d0c4e2e6