### PR TITLE
Start web server and simplify handlers

### DIFF
--- a/cmd/kuberhealthy/main.go
+++ b/cmd/kuberhealthy/main.go
@@ -47,6 +47,13 @@ func main() {
 		log.Errorln("startup: failed to setup kuberhealthy controller with error:", err)
 	}
 
+	// start the web status server
+	go func() {
+		if err := StartWebServer(); err != nil {
+			log.Errorln("web server error:", err)
+		}
+	}()
+
 	// we must know when a shutdown signal is trapped or the main context has been canceled
 	interruptChan := make(chan struct{})
 	go listenForInterrupts(ctx, interruptChan)

--- a/cmd/kuberhealthy/webserver_test.go
+++ b/cmd/kuberhealthy/webserver_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWebServerHandlers(t *testing.T) {
+	mux := newServeMux()
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	for _, p := range []string{"/", "/json"} {
+		resp, err := http.Get(ts.URL + p)
+		if err != nil {
+			t.Fatalf("failed to GET %s: %v", p, err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200 for %s got %d", p, resp.StatusCode)
+		}
+		resp.Body.Close()
+	}
+}


### PR DESCRIPTION
## Summary
- build an explicit ServeMux for status, metrics, and reporting handlers
- call StartWebServer from main so endpoints are served
- add basic test ensuring `/` and `/json` respond

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a81a98cb708323a231b6b5398d21aa