### PR TITLE
Add unit tests for health state and status report

### DIFF
--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -1,0 +1,61 @@
+package health
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	kuberhealthycheckv2 "github.com/kuberhealthy/crds/api/v2"
+)
+
+func TestAddError(t *testing.T) {
+	s := NewState()
+	s.AddError("", "error1", "", "error2")
+	if len(s.Errors) != 2 {
+		t.Fatalf("expected 2 errors, got %d", len(s.Errors))
+	}
+	if s.Errors[0] != "error1" || s.Errors[1] != "error2" {
+		t.Fatalf("unexpected errors slice: %#v", s.Errors)
+	}
+}
+
+func TestWriteHTTPStatusResponse(t *testing.T) {
+	s := State{
+		OK:     true,
+		Errors: []string{"e1"},
+		CheckDetails: map[string]kuberhealthycheckv2.KuberhealthyCheckStatus{
+			"check": {},
+		},
+		Metadata: map[string]string{"a": "b"},
+	}
+
+	rr := httptest.NewRecorder()
+	if err := s.WriteHTTPStatusResponse(rr); err != nil {
+		t.Fatalf("WriteHTTPStatusResponse returned error: %v", err)
+	}
+
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json; charset=utf-8" {
+		t.Fatalf("unexpected content type: %s", ct)
+	}
+
+	expected, _ := json.MarshalIndent(s, "", "  ")
+	if rr.Body.String() != string(expected) {
+		t.Fatalf("unexpected body: got %s want %s", rr.Body.String(), string(expected))
+	}
+}
+
+func TestNewState(t *testing.T) {
+	s := NewState()
+	if !s.OK {
+		t.Errorf("expected OK true, got false")
+	}
+	if s.Errors == nil || len(s.Errors) != 0 {
+		t.Errorf("expected empty error slice, got %#v", s.Errors)
+	}
+	if s.CheckDetails == nil || len(s.CheckDetails) != 0 {
+		t.Errorf("expected empty CheckDetails map, got %#v", s.CheckDetails)
+	}
+	if s.Metadata == nil || len(s.Metadata) != 0 {
+		t.Errorf("expected empty Metadata map, got %#v", s.Metadata)
+	}
+}

--- a/internal/health/status_test.go
+++ b/internal/health/status_test.go
@@ -1,0 +1,26 @@
+package health
+
+import "testing"
+
+func TestNewReportDefaultsOK(t *testing.T) {
+	r := NewReport(nil)
+	if !r.OK {
+		t.Errorf("expected OK true when errors slice is nil")
+	}
+
+	r = NewReport([]string{})
+	if !r.OK {
+		t.Errorf("expected OK true when errors slice is empty")
+	}
+}
+
+func TestNewReportWithErrors(t *testing.T) {
+	errs := []string{"err1"}
+	r := NewReport(errs)
+	if r.OK {
+		t.Errorf("expected OK false when errors are present")
+	}
+	if len(r.Errors) != len(errs) || r.Errors[0] != errs[0] {
+		t.Errorf("unexpected errors: %v", r.Errors)
+	}
+}


### PR DESCRIPTION
## Summary
- test AddError ignoring empty strings and appending real errors
- verify WriteHTTPStatusResponse writes JSON headers and body
- cover NewState and NewReport constructors

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a98a77c90c8323bcc799d960886dcc