### PR TITLE
test: add send report tests

### DIFF
--- a/pkg/checkclient/send_report_test.go
+++ b/pkg/checkclient/send_report_test.go
@@ -1,0 +1,109 @@
+package checkclient
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	kuberhealthycheckv2 "github.com/kuberhealthy/crds/api/v2"
+	"github.com/kuberhealthy/kuberhealthy/v3/internal/envs"
+)
+
+func TestReportSuccessAndFailure(t *testing.T) {
+	tests := []struct {
+		name     string
+		call     func() error
+		expected kuberhealthycheckv2.KuberhealthyCheckStatus
+	}{
+		{
+			name: "success",
+			call: ReportSuccess,
+			expected: kuberhealthycheckv2.KuberhealthyCheckStatus{
+				OK:     true,
+				Errors: []string{},
+			},
+		},
+		{
+			name: "failure",
+			call: func() error { return ReportFailure([]string{"err1", "err2"}) },
+			expected: kuberhealthycheckv2.KuberhealthyCheckStatus{
+				OK:     false,
+				Errors: []string{"err1", "err2"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotHeader string
+			var gotBody []byte
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotHeader = r.Header.Get("kh-run-uuid")
+				var err error
+				gotBody, err = io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatalf("failed reading body: %v", err)
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(srv.Close)
+
+			uuid := "test-uuid"
+			t.Setenv(envs.KHReportingURL, srv.URL)
+			t.Setenv(envs.KHRunUUID, uuid)
+
+			if err := tc.call(); err != nil {
+				t.Fatalf("call returned error: %v", err)
+			}
+
+			if gotHeader != uuid {
+				t.Fatalf("kh-run-uuid header = %q, want %q", gotHeader, uuid)
+			}
+
+			var status kuberhealthycheckv2.KuberhealthyCheckStatus
+			if err := json.Unmarshal(gotBody, &status); err != nil {
+				t.Fatalf("failed to unmarshal body: %v", err)
+			}
+			if status.OK != tc.expected.OK {
+				t.Fatalf("status OK = %v, want %v", status.OK, tc.expected.OK)
+			}
+			if len(status.Errors) != len(tc.expected.Errors) {
+				t.Fatalf("errors length = %d, want %d", len(status.Errors), len(tc.expected.Errors))
+			}
+			for i := range status.Errors {
+				if status.Errors[i] != tc.expected.Errors[i] {
+					t.Fatalf("error[%d] = %q, want %q", i, status.Errors[i], tc.expected.Errors[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSendReportRetry(t *testing.T) {
+	var reqs int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqs++
+		if reqs == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	uuid := "retry-uuid"
+	t.Setenv(envs.KHReportingURL, srv.URL)
+	t.Setenv(envs.KHRunUUID, uuid)
+
+	if err := ReportSuccess(); err != nil {
+		t.Fatalf("ReportSuccess returned error: %v", err)
+	}
+
+	if reqs != 2 {
+		t.Fatalf("expected 2 requests, got %d", reqs)
+	}
+}


### PR DESCRIPTION
## Summary
- add send_report_test to verify headers and body for success and failure
- add retry test to ensure sendReport backs off on non-200 responses

## Testing
- `go test ./pkg/checkclient -count=1`
- `go test ./... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68aada35ce288323895eaa264d8468b3