### PR TITLE
Add reaper for KHCheck pods

### DIFF
--- a/cmd/kuberhealthy/README.md
+++ b/cmd/kuberhealthy/README.md
@@ -12,19 +12,21 @@
 
 # Environment Variables
 ```
-KH_LISTEN_ADDRESS=":8080"
-KH_LOG_LEVEL="info"
-KH_MAX_JOB_AGE=""
-KH_MAX_CHECK_POD_AGE=""
-KH_MAX_COMPLETED_POD_COUNT="0"
-KH_MAX_ERROR_POD_COUNT="0"
-KH_PROM_SUPPRESS_ERROR_LABEL="false"
-KH_PROM_ERROR_LABEL_MAX_LENGTH="0"
-KH_TARGET_NAMESPACE="kuberhealthy"
-KH_DEFAULT_RUN_INTERVAL="10m"
-KH_CHECK_REPORT_HOSTNAME="kuberhealthy.kuberhealthy.svc.cluster.local"
-KH_TERMINATION_GRACE_PERIOD="5m"
-KH_DEFAULT_CHECK_TIMEOUT="5m"
-KH_DEBUG_MODE="false"
-KH_DEFAULT_NAMESPACE="kuberhealthy"
+KH_LISTEN_ADDRESS=":8080" # web server listen address
+KH_LOG_LEVEL="info" # log verbosity
+KH_MAX_JOB_AGE="" # max age for check jobs
+KH_MAX_CHECK_POD_AGE="" # max age for check pods
+KH_MAX_COMPLETED_POD_COUNT="0" # completed pods to retain
+KH_MAX_ERROR_POD_COUNT="5" # errored pods to retain for debugging
+KH_ERROR_POD_RETENTION_DAYS="4" # days to keep failed pods
+KH_PROM_SUPPRESS_ERROR_LABEL="false" # omit error label in metrics
+KH_PROM_ERROR_LABEL_MAX_LENGTH="0" # max length for error label
+KH_TARGET_NAMESPACE="kuberhealthy" # namespace to watch for checks
+POD_NAMESPACE="kuberhealthy" # namespace Kuberhealthy runs in
+KH_SERVICE_NAME="kuberhealthy" # service name used for reports
+KH_DEFAULT_RUN_INTERVAL="10m" # default check run interval
+KH_TERMINATION_GRACE_PERIOD="5m" # shutdown grace period
+KH_DEFAULT_CHECK_TIMEOUT="5m" # default check timeout
+KH_DEBUG_MODE="false" # enable debug mode
+KH_DEFAULT_NAMESPACE="kuberhealthy" # fallback namespace
 ```

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -34,7 +34,9 @@ spec:
         - name: KH_MAX_COMPLETED_POD_COUNT
           value: "0"
         - name: KH_MAX_ERROR_POD_COUNT
-          value: "0"
+          value: "5"
+        - name: KH_ERROR_POD_RETENTION_DAYS
+          value: "4"
         - name: KH_PROM_SUPPRESS_ERROR_LABEL
           value: "false"
         - name: KH_PROM_ERROR_LABEL_MAX_LENGTH
@@ -43,10 +45,14 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KH_SERVICE_NAME
+          value: "kuberhealthy"
         - name: KH_DEFAULT_RUN_INTERVAL
           value: "10m"
-        - name: KH_CHECK_REPORT_HOSTNAME
-          value: "kuberhealthy.kuberhealthy.svc.cluster.local"
         - name: KH_TERMINATION_GRACE_PERIOD
           value: "5m"
         - name: KH_DEFAULT_CHECK_TIMEOUT

--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -15,12 +15,15 @@ Available flags and environment variables for use in Kuberhealthy
 | `KH_MAX_JOB_AGE` | Maximum age for check jobs before cleanup | unset |
 | `KH_MAX_CHECK_POD_AGE` | Maximum age for check pods before cleanup | unset |
 | `KH_MAX_COMPLETED_POD_COUNT` | Number of completed pods to retain | `0` |
-| `KH_MAX_ERROR_POD_COUNT` | Number of error pods to retain | `0` |
+| `KH_MAX_ERROR_POD_COUNT` | Number of errored pods to always retain for debugging purposes | `5` |
+| `KH_ERROR_POD_RETENTION_DAYS` | Days to retain failed pods | `4` |
+| `POD_NAMESPACE` | Namespace Kuberhealthy runs in | <pod namespace> |
+| `KH_SERVICE_NAME` | Name of Kubernetes service where Kuberhealthy is available within the cluster | `kuberhealthy` |
 | `KH_PROM_SUPPRESS_ERROR_LABEL` | Omit error label in Prometheus metrics | `false` |
 | `KH_PROM_ERROR_LABEL_MAX_LENGTH` | Maximum length for Prometheus error label | `0` |
 | `KH_TARGET_NAMESPACE` | Namespace Kuberhealthy operates in (blank for all) | <pod namespace> |
 | `KH_DEFAULT_RUN_INTERVAL` | Default check run interval | `10m` |
-| `KH_CHECK_REPORT_HOSTNAME` | Hostname used for check reports | `kuberhealthy.kuberhealthy.svc.cluster.local` |
+| `KH_CHECK_REPORT_HOSTNAME` | Override hostname used for check reports | constructed |
 | `KH_TERMINATION_GRACE_PERIOD` | Shutdown grace period | `5m` |
 | `KH_DEFAULT_CHECK_TIMEOUT` | Default timeout for checks | `5m` |
 | `KH_DEBUG_MODE` | Enable debug mode | `false` |

--- a/internal/kuberhealthy/kuberhealthy_test.go
+++ b/internal/kuberhealthy/kuberhealthy_test.go
@@ -60,9 +60,9 @@ func TestCheckPodSpec(t *testing.T) {
 }
 
 func TestIsStarted(t *testing.T) {
-	kh := &Kuberhealthy{Running: true}
+	kh := &Kuberhealthy{running: true}
 	require.True(t, kh.IsStarted())
-	kh.Running = false
+	kh.running = false
 	require.False(t, kh.IsStarted())
 }
 

--- a/internal/kuberhealthy/reaper.go
+++ b/internal/kuberhealthy/reaper.go
@@ -1,6 +1,171 @@
 package kuberhealthy
 
-// TODO - implement a go routine that fetches all khcheck resources then iterates on them to find the pod with a matching UUID and check how long its been runninIg
-// TODO - kill any pods that have run past their deadline and set their khcheck status as failed with a reason of timeout
-// TODO - write an event when the khcheck failures occur to the namespace where the check ran
-// TODO - clean up all Completed checks with more than 3 completed pods
+import (
+	"context"
+	"log"
+	"os"
+	"sort"
+	"strconv"
+	"time"
+
+	khcrdsv2 "github.com/kuberhealthy/crds/api/v2"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	client "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// defaultRunInterval is the interval used when a check does not specify one.
+// This mirrors the default run interval used elsewhere in Kuberhealthy.
+const defaultRunInterval = time.Minute * 10
+
+// defaultRunTimeout is the amount of time a pod is allowed to run before the
+// reaper considers it timed out.
+const defaultRunTimeout = time.Minute * 5
+
+// defaultFailedPodRetentionDays is the number of days to retain failed pods
+// before they are reaped.
+const defaultFailedPodRetentionDays = 4
+
+// defaultMaxFailedPods is the maximum number of failed pods to retain for a
+// check.
+const defaultMaxFailedPods = 5
+
+// runReaper periodically scans all khcheck pods and cleans up any that have
+// exceeded their configured runtime or have lingered after completion.
+func (kh *Kuberhealthy) runReaper(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := kh.reapOnce(); err != nil {
+				log.Println("reaper:", err)
+			}
+		}
+	}
+}
+
+// reapOnce performs a single scan of khchecks and applies cleanup logic. It is
+// primarily exposed for unit testing.
+func (kh *Kuberhealthy) reapOnce() error {
+	var checkList khcrdsv2.KuberhealthyCheckList
+	if err := kh.CheckClient.List(kh.Context, &checkList); err != nil {
+		return err
+	}
+
+	// read configuration from environment variables
+	retention := time.Duration(defaultFailedPodRetentionDays) * 24 * time.Hour
+	if v := os.Getenv("KH_ERROR_POD_RETENTION_DAYS"); v != "" {
+		if i, err := strconv.Atoi(v); err == nil && i > 0 {
+			retention = time.Duration(i) * 24 * time.Hour
+		}
+	}
+	maxFailed := defaultMaxFailedPods
+	if v := os.Getenv("KH_MAX_ERROR_POD_COUNT"); v != "" {
+		if i, err := strconv.Atoi(v); err == nil && i > 0 {
+			maxFailed = i
+		}
+	}
+
+	for i := range checkList.Items {
+		check := &checkList.Items[i]
+		checkNN := types.NamespacedName{Namespace: check.Namespace, Name: check.Name}
+
+		// determine runtime parameters from the check spec if provided
+		runTimeout := defaultRunTimeout
+		runInterval := defaultRunInterval
+
+		raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(check)
+		if err == nil {
+			if spec, ok := raw["spec"].(map[string]interface{}); ok {
+				if v, ok := spec["runTimeout"].(string); ok {
+					if d, err := time.ParseDuration(v); err == nil {
+						runTimeout = d
+					}
+				}
+				if v, ok := spec["runInterval"].(string); ok {
+					if d, err := time.ParseDuration(v); err == nil {
+						runInterval = d
+					}
+				}
+			}
+		}
+
+		// list pods belonging to this check
+		var podList corev1.PodList
+		if err := kh.CheckClient.List(kh.Context, &podList,
+			client.InNamespace(check.Namespace),
+			client.MatchingLabels(map[string]string{"khcheck": check.Name}),
+		); err != nil {
+			log.Printf("reaper: list pods for %s/%s: %v", check.Namespace, check.Name, err)
+			continue
+		}
+
+		var failedPods []corev1.Pod
+
+		// iterate over each pod and apply retention logic based on phase
+		for pod := range podList.Items {
+			podRef := &podList.Items[pod]
+			age := time.Since(podRef.CreationTimestamp.Time)
+
+			switch podRef.Status.Phase {
+			case corev1.PodRunning, corev1.PodPending, corev1.PodUnknown:
+				// terminate pods running longer than the allowed timeout
+				if age > runTimeout {
+					if err := kh.CheckClient.Delete(kh.Context, podRef); err != nil && !apierrors.IsNotFound(err) {
+						log.Printf("reaper: failed deleting timed out pod %s/%s: %v", podRef.Namespace, podRef.Name, err)
+						continue
+					}
+					_ = kh.setCheckExecutionError(checkNN, []string{"check run timed out"})
+					_ = kh.setOK(checkNN, false)
+					_ = kh.clearUUID(checkNN)
+					if check.Status.PodName == podRef.Name {
+						_ = kh.setCheckPodName(checkNN, "")
+					}
+				}
+			case corev1.PodSucceeded:
+				// prune successful pods after three intervals
+				if age > runInterval*3 {
+					if err := kh.CheckClient.Delete(kh.Context, podRef); err != nil && !apierrors.IsNotFound(err) {
+						log.Printf("reaper: failed deleting completed pod %s/%s: %v", podRef.Namespace, podRef.Name, err)
+						continue
+					}
+					if check.Status.PodName == podRef.Name {
+						_ = kh.setCheckPodName(checkNN, "")
+					}
+				}
+			case corev1.PodFailed:
+				// accumulate failed pods for later pruning
+				failedPods = append(failedPods, *podRef)
+			default:
+				log.Printf("reaper: encountered pod %s/%s with unexpected phase %s", podRef.Namespace, podRef.Name, podRef.Status.Phase)
+			}
+		}
+
+		// sort failed pods newest first
+		sort.Slice(failedPods, func(i, j int) bool {
+			return failedPods[i].CreationTimestamp.Time.After(failedPods[j].CreationTimestamp.Time)
+		})
+
+		// delete failed pods exceeding retention settings
+		for pod := range failedPods {
+			podRef := &failedPods[pod]
+			age := time.Since(podRef.CreationTimestamp.Time)
+			if pod >= maxFailed || age > retention {
+				if err := kh.CheckClient.Delete(kh.Context, podRef); err != nil && !apierrors.IsNotFound(err) {
+					log.Printf("reaper: failed deleting failed pod %s/%s: %v", podRef.Namespace, podRef.Name, err)
+					continue
+				}
+				if check.Status.PodName == podRef.Name {
+					_ = kh.setCheckPodName(checkNN, "")
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/internal/kuberhealthy/reaper_test.go
+++ b/internal/kuberhealthy/reaper_test.go
@@ -1,0 +1,337 @@
+package kuberhealthy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	khcrdsv2 "github.com/kuberhealthy/crds/api/v2"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	client "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// Test that pods running past their timeout are terminated and the check is
+// marked as failed.
+func TestReaperTimesOutRunningPod(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, khcrdsv2.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	lastRun := time.Now().Add(-time.Hour)
+
+	check := &khcrdsv2.KuberhealthyCheck{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "timeout-check",
+			Namespace:       "default",
+			ResourceVersion: "1",
+		},
+		Status: khcrdsv2.KuberhealthyCheckStatus{
+			PodName:     "timeout-pod",
+			CurrentUUID: "abc123",
+			LastRunUnix: lastRun.Unix(),
+			OK:          true,
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "timeout-pod",
+			Namespace:         "default",
+			Labels:            map[string]string{"khcheck": check.Name},
+			CreationTimestamp: metav1.Time{Time: lastRun},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithRuntimeObjects(check, pod).
+		WithStatusSubresource(check).
+		Build()
+
+	kh := New(context.Background(), cl)
+
+	require.NoError(t, kh.reapOnce())
+
+	// Pod should be deleted
+	err := cl.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "timeout-pod"}, &corev1.Pod{})
+	require.True(t, apierrors.IsNotFound(err))
+
+	// Check status should show timeout
+	updated := &khcrdsv2.KuberhealthyCheck{}
+	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "timeout-check"}, updated))
+	require.False(t, updated.Status.OK)
+	require.Len(t, updated.Status.Errors, 1)
+	require.Contains(t, updated.Status.Errors[0], "timed out")
+	require.Empty(t, updated.Status.PodName)
+	require.Empty(t, updated.Status.CurrentUUID)
+}
+
+// Test that completed pods are removed after three run intervals have passed.
+func TestReaperRemovesCompletedPods(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, khcrdsv2.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	lastRun := time.Now().Add(-defaultRunInterval*3 - time.Minute)
+
+	check := &khcrdsv2.KuberhealthyCheck{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "complete-check",
+			Namespace:       "default",
+			ResourceVersion: "1",
+		},
+		Status: khcrdsv2.KuberhealthyCheckStatus{
+			PodName:     "complete-pod",
+			LastRunUnix: lastRun.Unix(),
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "complete-pod",
+			Namespace:         "default",
+			Labels:            map[string]string{"khcheck": check.Name},
+			CreationTimestamp: metav1.Time{Time: lastRun},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodSucceeded},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithRuntimeObjects(check, pod).
+		WithStatusSubresource(check).
+		Build()
+
+	kh := New(context.Background(), cl)
+
+	require.NoError(t, kh.reapOnce())
+
+	// Pod should be deleted after grace period
+	err := cl.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "complete-pod"}, &corev1.Pod{})
+	require.True(t, apierrors.IsNotFound(err))
+}
+
+// Test that completed pods younger than three run intervals remain.
+func TestReaperKeepsRecentCompletedPods(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, khcrdsv2.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	lastRun := time.Now().Add(-defaultRunInterval * 2)
+
+	check := &khcrdsv2.KuberhealthyCheck{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "recent-check",
+			Namespace:       "default",
+			ResourceVersion: "1",
+		},
+		Status: khcrdsv2.KuberhealthyCheckStatus{
+			PodName:     "recent-pod",
+			LastRunUnix: lastRun.Unix(),
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "recent-pod",
+			Namespace:         "default",
+			Labels:            map[string]string{"khcheck": check.Name},
+			CreationTimestamp: metav1.Time{Time: lastRun},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodSucceeded},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithRuntimeObjects(check, pod).
+		WithStatusSubresource(check).
+		Build()
+
+	kh := New(context.Background(), cl)
+
+	require.NoError(t, kh.reapOnce())
+
+	// Pod should still exist because grace period has not elapsed
+	err := cl.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "recent-pod"}, &corev1.Pod{})
+	require.NoError(t, err)
+}
+
+// Test that failed pods are pruned according to retention and max count settings.
+func TestReaperPrunesFailedPods(t *testing.T) {
+	t.Setenv("KH_ERROR_POD_RETENTION_DAYS", "2")
+	t.Setenv("KH_MAX_ERROR_POD_COUNT", "2")
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, khcrdsv2.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	check := &khcrdsv2.KuberhealthyCheck{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "failed-check",
+			Namespace:       "default",
+			ResourceVersion: "1",
+		},
+	}
+
+	now := time.Now()
+	pods := []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "failed-oldest",
+				Namespace:         "default",
+				Labels:            map[string]string{"khcheck": check.Name},
+				CreationTimestamp: metav1.Time{Time: now.Add(-23 * time.Hour)},
+			},
+			Status: corev1.PodStatus{Phase: corev1.PodFailed},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "failed-middle",
+				Namespace:         "default",
+				Labels:            map[string]string{"khcheck": check.Name},
+				CreationTimestamp: metav1.Time{Time: now.Add(-22 * time.Hour)},
+			},
+			Status: corev1.PodStatus{Phase: corev1.PodFailed},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "failed-newest",
+				Namespace:         "default",
+				Labels:            map[string]string{"khcheck": check.Name},
+				CreationTimestamp: metav1.Time{Time: now.Add(-21 * time.Hour)},
+			},
+			Status: corev1.PodStatus{Phase: corev1.PodFailed},
+		},
+	}
+
+	objs := []runtime.Object{check}
+	for i := range pods {
+		p := pods[i]
+		objs = append(objs, &p)
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).WithStatusSubresource(check).Build()
+	kh := New(context.Background(), cl)
+
+	require.NoError(t, kh.reapOnce())
+
+	var remaining corev1.PodList
+	require.NoError(t, cl.List(context.Background(), &remaining, client.InNamespace("default"), client.MatchingLabels(map[string]string{"khcheck": check.Name})))
+	require.Len(t, remaining.Items, 2)
+	names := []string{remaining.Items[0].Name, remaining.Items[1].Name}
+	require.NotContains(t, names, "failed-oldest")
+}
+
+// Test that failed pods within retention limits are preserved.
+func TestReaperRetainsFailedPodsWithinRetention(t *testing.T) {
+	t.Setenv("KH_ERROR_POD_RETENTION_DAYS", "2")
+	t.Setenv("KH_MAX_ERROR_POD_COUNT", "3")
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, khcrdsv2.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	check := &khcrdsv2.KuberhealthyCheck{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "retain-check",
+			Namespace:       "default",
+			ResourceVersion: "1",
+		},
+	}
+
+	now := time.Now()
+	pods := []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "failed-one",
+				Namespace:         "default",
+				Labels:            map[string]string{"khcheck": check.Name},
+				CreationTimestamp: metav1.Time{Time: now.Add(-2 * time.Hour)},
+			},
+			Status: corev1.PodStatus{Phase: corev1.PodFailed},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "failed-two",
+				Namespace:         "default",
+				Labels:            map[string]string{"khcheck": check.Name},
+				CreationTimestamp: metav1.Time{Time: now.Add(-time.Hour)},
+			},
+			Status: corev1.PodStatus{Phase: corev1.PodFailed},
+		},
+	}
+
+	objs := []runtime.Object{check}
+	for i := range pods {
+		p := pods[i]
+		objs = append(objs, &p)
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).WithStatusSubresource(check).Build()
+	kh := New(context.Background(), cl)
+
+	require.NoError(t, kh.reapOnce())
+
+	var remaining corev1.PodList
+	require.NoError(t, cl.List(context.Background(), &remaining, client.InNamespace("default"), client.MatchingLabels(map[string]string{"khcheck": check.Name})))
+	require.Len(t, remaining.Items, 2)
+}
+
+// Test that failed pods older than the retention period are removed.
+func TestReaperDeletesFailedPodsPastRetention(t *testing.T) {
+	t.Setenv("KH_ERROR_POD_RETENTION_DAYS", "1")
+	t.Setenv("KH_MAX_ERROR_POD_COUNT", "5")
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, khcrdsv2.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	check := &khcrdsv2.KuberhealthyCheck{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "old-check",
+			Namespace:       "default",
+			ResourceVersion: "1",
+		},
+	}
+
+	now := time.Now()
+	pods := []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "failed-oldest",
+				Namespace:         "default",
+				Labels:            map[string]string{"khcheck": check.Name},
+				CreationTimestamp: metav1.Time{Time: now.Add(-26 * time.Hour)},
+			},
+			Status: corev1.PodStatus{Phase: corev1.PodFailed},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "failed-older",
+				Namespace:         "default",
+				Labels:            map[string]string{"khcheck": check.Name},
+				CreationTimestamp: metav1.Time{Time: now.Add(-25 * time.Hour)},
+			},
+			Status: corev1.PodStatus{Phase: corev1.PodFailed},
+		},
+	}
+
+	objs := []runtime.Object{check}
+	for i := range pods {
+		p := pods[i]
+		objs = append(objs, &p)
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).WithStatusSubresource(check).Build()
+	kh := New(context.Background(), cl)
+
+	require.NoError(t, kh.reapOnce())
+
+	var remaining corev1.PodList
+	require.NoError(t, cl.List(context.Background(), &remaining, client.InNamespace("default"), client.MatchingLabels(map[string]string{"khcheck": check.Name})))
+	require.Len(t, remaining.Items, 0)
+}


### PR DESCRIPTION
## Summary
- compute check report host from service and namespace env vars, wiring through deployment
- privatize controller running state and clarify pod reaper logic with additional logging
- document service/namespace environment variables and error pod retention controls
- test reaper pod retention for completed and failed pods

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a989c4790483238ad84f93075f50ce