### PR TITLE
Parallelize selected tests

### DIFF
--- a/cmd/kuberhealthy/check_report_handler_test.go
+++ b/cmd/kuberhealthy/check_report_handler_test.go
@@ -18,6 +18,7 @@ func TestCheckReportHandler(t *testing.T) {
 	origValidateHeader := validateUsingRequestHeaderFunc
 	origValidateIP := validatePodReportBySourceIPFunc
 	origStore := storeCheckStateFunc
+	t.Parallel()
 	defer func() {
 		validateUsingRequestHeaderFunc = origValidateHeader
 		validatePodReportBySourceIPFunc = origValidateIP

--- a/cmd/kuberhealthy/metrics_handler_test.go
+++ b/cmd/kuberhealthy/metrics_handler_test.go
@@ -14,6 +14,14 @@ import (
 )
 
 func TestPrometheusMetricsEndpoint(t *testing.T) {
+	t.Parallel()
+	origController := KHController
+	origConfig := GlobalConfig
+	t.Cleanup(func() {
+		KHController = origController
+		GlobalConfig = origConfig
+	})
+
 	s := runtime.NewScheme()
 	if err := kuberhealthycheckv2.AddToScheme(s); err != nil {
 		t.Fatalf("failed to add scheme: %v", err)

--- a/cmd/kuberhealthy/webserver_test.go
+++ b/cmd/kuberhealthy/webserver_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestWebServerHandlers(t *testing.T) {
+	t.Parallel()
 	mux := newServeMux()
 	ts := httptest.NewServer(mux)
 	defer ts.Close()

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAddError(t *testing.T) {
+	t.Parallel()
 	s := NewState()
 	s.AddError("", "error1", "", "error2")
 	if len(s.Errors) != 2 {
@@ -20,6 +21,7 @@ func TestAddError(t *testing.T) {
 }
 
 func TestWriteHTTPStatusResponse(t *testing.T) {
+	t.Parallel()
 	s := State{
 		OK:     true,
 		Errors: []string{"e1"},
@@ -45,6 +47,7 @@ func TestWriteHTTPStatusResponse(t *testing.T) {
 }
 
 func TestNewState(t *testing.T) {
+	t.Parallel()
 	s := NewState()
 	if !s.OK {
 		t.Errorf("expected OK true, got false")

--- a/internal/health/status_test.go
+++ b/internal/health/status_test.go
@@ -3,6 +3,7 @@ package health
 import "testing"
 
 func TestNewReportDefaultsOK(t *testing.T) {
+	t.Parallel()
 	r := NewReport(nil)
 	if !r.OK {
 		t.Errorf("expected OK true when errors slice is nil")
@@ -15,6 +16,7 @@ func TestNewReportDefaultsOK(t *testing.T) {
 }
 
 func TestNewReportWithErrors(t *testing.T) {
+	t.Parallel()
 	errs := []string{"err1"}
 	r := NewReport(errs)
 	if r.OK {

--- a/internal/kuberhealthy/kuberhealthy_test.go
+++ b/internal/kuberhealthy/kuberhealthy_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestCheckPodSpec(t *testing.T) {
+	t.Parallel()
 	kh := New(context.Background(), nil)
 
 	check := &khcrdsv2.KuberhealthyCheck{
@@ -60,6 +61,7 @@ func TestCheckPodSpec(t *testing.T) {
 }
 
 func TestIsStarted(t *testing.T) {
+	t.Parallel()
 	kh := &Kuberhealthy{Running: true}
 	require.True(t, kh.IsStarted())
 	kh.Running = false
@@ -67,6 +69,7 @@ func TestIsStarted(t *testing.T) {
 }
 
 func TestSetAndGetCheckPodName(t *testing.T) {
+	t.Parallel()
 	scheme := runtime.NewScheme()
 	require.NoError(t, khcrdsv2.AddToScheme(scheme))
 
@@ -91,6 +94,7 @@ func TestSetAndGetCheckPodName(t *testing.T) {
 }
 
 func TestSetFreshUUID(t *testing.T) {
+	t.Parallel()
 	scheme := runtime.NewScheme()
 	require.NoError(t, khcrdsv2.AddToScheme(scheme))
 

--- a/pkg/checkclient/checkclient_test.go
+++ b/pkg/checkclient/checkclient_test.go
@@ -10,6 +10,9 @@ import (
 
 // TestGetKuberhealthyURL ensures that KH_REPORTING_URL env var can be fetched
 func TestGetKuberhealthyURL(t *testing.T) {
+	t.Parallel()
+	orig := os.Getenv(envs.KHReportingURL)
+	t.Cleanup(func() { os.Setenv(envs.KHReportingURL, orig) })
 
 	var testCases = []struct {
 		input string
@@ -41,6 +44,9 @@ func TestGetKuberhealthyURL(t *testing.T) {
 
 // TestGetKuberhealthyRunUUID ensures that KH_RUN_UUID env var can be fetched
 func TestGetKuberhealthyRunUUID(t *testing.T) {
+	t.Parallel()
+	orig := os.Getenv(envs.KHRunUUID)
+	t.Cleanup(func() { os.Setenv(envs.KHRunUUID, orig) })
 
 	var testCases = []struct {
 		input string
@@ -72,6 +78,9 @@ func TestGetKuberhealthyRunUUID(t *testing.T) {
 
 // TestGetDeadline ensures that KH_CHECK_RUN_DEADLINE env var can be fetched and parsed
 func TestGetDeadline(t *testing.T) {
+	t.Parallel()
+	orig := os.Getenv(envs.KHDeadline)
+	t.Cleanup(func() { os.Setenv(envs.KHDeadline, orig) })
 
 	var testCases = []struct {
 		input     string

--- a/pkg/nodecheck/nodecheck_test.go
+++ b/pkg/nodecheck/nodecheck_test.go
@@ -14,6 +14,7 @@ func init() {
 }
 
 func TestWaitForKuberhealthyEndpointReady(t *testing.T) {
+	t.Parallel()
 	khEndpoint := "http://127.0.0.1:65535/"
 	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
 	err := <-waitForKuberhealthyEndpointReady(ctx, khEndpoint)


### PR DESCRIPTION
## Summary
- run several test functions with `t.Parallel()`
- reset global state and env vars to avoid cross-test interference

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68aaddc651888323b454e077390c9cd7