### PR TITLE
Reject OK reports with errors in check handler

### DIFF
--- a/cmd/kuberhealthy/check_report_handler_test.go
+++ b/cmd/kuberhealthy/check_report_handler_test.go
@@ -96,4 +96,37 @@ func TestCheckReportHandler(t *testing.T) {
 			t.Fatalf("storeCheckState should not be called on invalid report")
 		}
 	})
+
+	t.Run("errors present when OK", func(t *testing.T) {
+		validateUsingRequestHeaderFunc = func(ctx context.Context, r *http.Request) (PodReportInfo, bool, error) {
+			return PodReportInfo{Name: "my-check", Namespace: "my-namespace", UUID: "abc"}, true, nil
+		}
+		validatePodReportBySourceIPFunc = func(ctx context.Context, r *http.Request) (PodReportInfo, error) {
+			t.Fatalf("unexpected call to validatePodReportBySourceIPFunc")
+			return PodReportInfo{}, nil
+		}
+		storeCalled := false
+		storeCheckStateFunc = func(string, string, *kuberhealthycheckv2.KuberhealthyCheckStatus) error {
+			storeCalled = true
+			return nil
+		}
+
+		report := health.Report{OK: true, Errors: []string{"error"}}
+		b, err := json.Marshal(report)
+		if err != nil {
+			t.Fatalf("failed to marshal report: %v", err)
+		}
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(b))
+		rr := httptest.NewRecorder()
+
+		if err := checkReportHandler(rr, req); err != nil {
+			t.Fatalf("handler returned error: %v", err)
+		}
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
+		}
+		if storeCalled {
+			t.Fatalf("storeCheckState should not be called on invalid report")
+		}
+	})
 }

--- a/cmd/kuberhealthy/webserver.go
+++ b/cmd/kuberhealthy/webserver.go
@@ -331,6 +331,13 @@ func checkReportHandler(w http.ResponseWriter, r *http.Request) error {
 	}
 	log.Debugf("Check report after unmarshal: +%v\n", state)
 
+	// ensure that reports do not contain errors when OK is true
+	if state.OK && len(state.Errors) > 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		log.Println("webserver:", requestID, "Client attempted to report OK true with error strings")
+		return nil
+	}
+
 	// ensure that if ok is set to false, then an error is provided
 	if !state.OK {
 		if len(state.Errors) == 0 {


### PR DESCRIPTION
## Summary
- reject reports that include error strings when OK is true
- test checkReportHandler rejects OK report with errors

## Testing
- `go test ./cmd/kuberhealthy -run TestCheckReportHandler -count=1` *(fails: internal/kuberhealthy/reaper.go:21:7: defaultRunInterval redeclared in this block; internal/kuberhealthy/kuberhealthy.go:23:2: other declaration of defaultRunInterval)*

------
https://chatgpt.com/codex/tasks/task_e_68aae15852f48323babe189541d81e8f