### PR TITLE
Store check status on khcheck with retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Kuberhealthy is configured entirely with environment variables. The deployment m
 
 #### See Configured Checks
 
-You can see checks that are configured with `kubectl -n kuberhealthy get khcheck`.  Check status can be accessed by the JSON status page endpoint, or via `kubectl -n kuberhealthy get khstate`.
+You can see checks that are configured with `kubectl -n kuberhealthy get khcheck`. Check status can be accessed via the JSON status page endpoint or by inspecting the status field on the `khcheck` resource.
 
 
 ### Further Configuration

--- a/cmd/kuberhealthy/store_check_state_test.go
+++ b/cmd/kuberhealthy/store_check_state_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	kuberhealthycheckv2 "github.com/kuberhealthy/crds/api/v2"
+	"github.com/kuberhealthy/kuberhealthy/v3/internal/controller"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+type conflictClient struct {
+	client.Client
+	updateCalls int
+}
+
+func (c *conflictClient) Status() client.StatusWriter {
+	return &conflictStatusWriter{StatusWriter: c.Client.Status(), parent: c}
+}
+
+type conflictStatusWriter struct {
+	client.StatusWriter
+	parent *conflictClient
+}
+
+func (w *conflictStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	w.parent.updateCalls++
+	if w.parent.updateCalls == 1 {
+		return fmt.Errorf("the object has been modified")
+	}
+	return w.StatusWriter.Update(ctx, obj, opts...)
+}
+
+func TestStoreCheckStateRetriesOnConflict(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := kuberhealthycheckv2.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add scheme: %v", err)
+	}
+	existing := &kuberhealthycheckv2.KuberhealthyCheck{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "conflict-check",
+			Namespace: "default",
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).WithStatusSubresource(existing).Build()
+	cc := &conflictClient{Client: fakeClient}
+
+	origController := KHController
+	t.Cleanup(func() { KHController = origController })
+	KHController = &controller.KuberhealthyCheckReconciler{Client: cc}
+
+	status := &kuberhealthycheckv2.KuberhealthyCheckStatus{OK: true}
+	if err := storeCheckState("conflict-check", "default", status); err != nil {
+		t.Fatalf("storeCheckState returned error: %v", err)
+	}
+	if cc.updateCalls < 2 {
+		t.Fatalf("expected at least 2 update calls, got %d", cc.updateCalls)
+	}
+
+	var updated kuberhealthycheckv2.KuberhealthyCheck
+	if err := cc.Get(context.Background(), types.NamespacedName{Name: "conflict-check", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("failed to get updated khcheck: %v", err)
+	}
+	if !updated.Status.OK {
+		t.Fatalf("expected status OK true, got false")
+	}
+}

--- a/internal/kuberhealthy/reaper.go
+++ b/internal/kuberhealthy/reaper.go
@@ -16,10 +16,6 @@ import (
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// defaultRunInterval is the interval used when a check does not specify one.
-// This mirrors the default run interval used elsewhere in Kuberhealthy.
-const defaultRunInterval = time.Minute * 10
-
 // defaultRunTimeout is the amount of time a pod is allowed to run before the
 // reaper considers it timed out.
 const defaultRunTimeout = time.Minute * 5


### PR DESCRIPTION
## Summary
- remove khstate usage and store check results on khcheck status fields
- retry status updates on conflicts and adjust test accordingly
- document how to inspect check status via khcheck resources

## Testing
- `go test -vet=off ./cmd/kuberhealthy -run TestStoreCheckStateRetriesOnConflict -count=1 -v`
- `go test -vet=off ./... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68aae163a9d48323a4c8fb23a277a741