### PR TITLE
Run tests on PRs and limit image builds to merges

### DIFF
--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -2,6 +2,8 @@ name: Build and Push Image
 
 on:
   push:
+    branches:
+      - master
     paths:
       - 'cmd/**'
       - 'internal/**'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: Run Tests
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21.5'
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Run tests
+        run: go test ./...


### PR DESCRIPTION
## Summary
- run Go unit tests on each pull request
- restrict image build workflow to run only after merges

## Testing
- `go test ./...` *(fails: defaultRunInterval redeclared in internal/kuberhealthy)*

------
https://chatgpt.com/codex/tasks/task_e_68aae8052e1c83238cac7bbf7cf4ab61