### PR TITLE
feat: enhance web UI with pod details

### DIFF
--- a/cmd/kuberhealthy/Podfile
+++ b/cmd/kuberhealthy/Podfile
@@ -7,6 +7,7 @@ RUN go version
 ENV CGO_ENABLED=0
 RUN mkdir /app
 RUN go build -v -o /app/kuberhealthy
+RUN cp /src/openapi.yaml /app/openapi.yaml
 
 FROM scratch
 WORKDIR /app

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -47,6 +47,54 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/State'
+  /api/pods:
+    get:
+      summary: List checker pods for a check
+      parameters:
+        - in: query
+          name: namespace
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: check
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Pod list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PodSummary'
+        '400':
+          description: Missing parameters
+  /api/logs:
+    get:
+      summary: Retrieve logs for a checker pod
+      parameters:
+        - in: query
+          name: namespace
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: pod
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Pod logs
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PodLog'
+        '400':
+          description: Missing parameters
   /check:
     post:
       summary: Report an external check result
@@ -145,3 +193,43 @@ components:
           type: boolean
       required:
         - ok
+    PodSummary:
+      type: object
+      properties:
+        name:
+          type: string
+        namespace:
+          type: string
+        phase:
+          type: string
+        startTime:
+          type: integer
+          format: int64
+        durationSeconds:
+          type: integer
+          format: int64
+      required:
+        - name
+        - namespace
+        - phase
+    PodLog:
+      type: object
+      properties:
+        name:
+          type: string
+        namespace:
+          type: string
+        phase:
+          type: string
+        startTime:
+          type: integer
+          format: int64
+        durationSeconds:
+          type: integer
+          format: int64
+        logs:
+          type: string
+      required:
+        - name
+        - namespace
+        - phase


### PR DESCRIPTION
## Summary
- build a richer HTML status page with a left-hand menu, pod selection, and log display
- expose `/api/pods` and `/api/logs` endpoints to fetch pod lists and logs for checks
- update and serve `openapi.yaml` so users can download the API spec
- include `openapi.yaml` in container image via Podfile

## Testing
- `go test ./...` *(fails: defaultRunInterval redeclared in this block)*

------
https://chatgpt.com/codex/tasks/task_e_68aae8f933888323ba64c497618c4d89