### PR TITLE
Fix status page 404 on root

### DIFF
--- a/cmd/kuberhealthy/webserver.go
+++ b/cmd/kuberhealthy/webserver.go
@@ -202,7 +202,8 @@ func StartWebServer() error {
 // to show the status of all configured checks.
 func statusPageHandler(w http.ResponseWriter, r *http.Request) error {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	_, err := w.Write([]byte(statusPageHTML))
+	w.WriteHeader(http.StatusOK)
+	_, err := io.WriteString(w, statusPageHTML)
 	if err != nil {
 		log.Warningln("Error writing status page:", err)
 	}


### PR DESCRIPTION
## Summary
- ensure status page handler always writes an OK status before rendering
- test root path serves the user interface

## Testing
- `go test ./cmd/kuberhealthy -run TestRootServesUserInterface -count=1 -v` *(fails: command did not complete in time)*

------
https://chatgpt.com/codex/tasks/task_e_68abb8879dc0832395671a398ef71d75