### PR TITLE
refactor: use logrus for logging

### DIFF
--- a/internal/controller/kuberhealthycheck_controller.go
+++ b/internal/controller/kuberhealthycheck_controller.go
@@ -18,9 +18,8 @@ package controller
 
 import (
 	"context"
-	"fmt"
-	"log"
 
+	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -51,7 +50,7 @@ type KuberhealthyCheckReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.18.4/pkg/reconcile
 func (r *KuberhealthyCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	fmt.Println("-- controller Reconcile")
+	log.Debugln("controller: Reconcile")
 	var check khcrdsv2.KuberhealthyCheck
 	if err := r.Get(ctx, req.NamespacedName, &check); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -62,7 +61,7 @@ func (r *KuberhealthyCheckReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// DELETE support for finalizer
 	if !check.ObjectMeta.DeletionTimestamp.IsZero() {
 		if controllerutil.ContainsFinalizer(&check, finalizer) {
-			log.Println("controller: FINALIZER DELETE event detected for:", req.Namespace+"/"+req.Name)
+			log.Infoln("controller: FINALIZER DELETE event detected for:", req.Namespace+"/"+req.Name)
 
 			// Remove finalizer and update the resource
 			controllerutil.RemoveFinalizer(&check, finalizer)

--- a/internal/controller/new.go
+++ b/internal/controller/new.go
@@ -6,6 +6,7 @@ import (
 
 	khcrdsv2 "github.com/kuberhealthy/crds/api/v2"
 	"github.com/kuberhealthy/kuberhealthy/v3/internal/kuberhealthy"
+	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/rest"
@@ -15,7 +16,7 @@ import (
 // New creates a new KuberhealthyCheckReconciler with a working controller manager from the kubebuilder packages.
 // Expects a kuberhealthy.Kuberhealthy. If it is not started, then this function will start it.
 func New(ctx context.Context, cfg *rest.Config) (*KuberhealthyCheckReconciler, error) {
-	fmt.Println("Starting new Kuberhealthy Controller")
+	log.Debugln("controller: starting new Kuberhealthy Controller")
 
 	scheme := runtime.NewScheme()
 	utilruntime.Must(khcrdsv2.AddToScheme(scheme))

--- a/internal/controller/setupWithManager.go
+++ b/internal/controller/setupWithManager.go
@@ -2,9 +2,9 @@ package controller
 
 import (
 	"fmt"
-	"log"
 	"reflect"
 
+	log "github.com/sirupsen/logrus"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -16,16 +16,16 @@ import (
 // setupWithManager registers the controller with filtering for create events. This automatically
 // starts the manager that is passed in.
 func (r *KuberhealthyCheckReconciler) setupWithManager(mgr ctrl.Manager) error {
-	fmt.Println("-- controller setupWithManager")
+	log.Debugln("controller: setupWithManager")
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&khcrdsv2.KuberhealthyCheck{}).
 		WithEventFilter(predicate.Funcs{
 			// CREATE
 			CreateFunc: func(e event.CreateEvent) bool {
-				log.Println("controller: CREATE event detected for:", e.Object.GetName())
+				log.Infoln("controller: CREATE event detected for:", e.Object.GetName())
 				khcheck, err := convertToKHCheck(e.Object)
 				if err != nil {
-					log.Println("error:", err.Error())
+					log.Errorln("error:", err.Error())
 					return false
 				}
 				err = r.Kuberhealthy.StartCheck(khcheck) // Start new instance of check
@@ -33,15 +33,15 @@ func (r *KuberhealthyCheckReconciler) setupWithManager(mgr ctrl.Manager) error {
 			},
 			// UPDATE
 			UpdateFunc: func(e event.UpdateEvent) bool {
-				log.Println("controller: UPDATE event detected for:", e.ObjectOld.GetName())
+				log.Infoln("controller: UPDATE event detected for:", e.ObjectOld.GetName())
 				oldKHCheck, err := convertToKHCheck(e.ObjectOld)
 				if err != nil {
-					log.Println("error:", err.Error())
+					log.Errorln("error:", err.Error())
 					return false
 				}
 				newKHCheck, err := convertToKHCheck(e.ObjectNew)
 				if err != nil {
-					log.Println("error:", err.Error())
+					log.Errorln("error:", err.Error())
 					return false
 				}
 				r.Kuberhealthy.UpdateCheck(oldKHCheck, newKHCheck)
@@ -50,10 +50,10 @@ func (r *KuberhealthyCheckReconciler) setupWithManager(mgr ctrl.Manager) error {
 			// DELETE
 			// TODO - do we need this DELETE and the one in Reconcile?
 			DeleteFunc: func(e event.DeleteEvent) bool {
-				log.Println("controller: DELETE event detected for:", e.Object.GetName())
+				log.Infoln("controller: DELETE event detected for:", e.Object.GetName())
 				khcheck, err := convertToKHCheck(e.Object)
 				if err != nil {
-					log.Println("error:", err.Error())
+					log.Errorln("error:", err.Error())
 					return false
 				}
 				err = r.Kuberhealthy.StopCheck(khcheck) // Start new instance of check

--- a/pkg/checkclient/checkclient.go
+++ b/pkg/checkclient/checkclient.go
@@ -8,13 +8,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"strconv"
 	"time"
 
 	"github.com/cenkalti/backoff"
+	log "github.com/sirupsen/logrus"
 
 	kuberhealthycheckv2 "github.com/kuberhealthy/crds/api/v2"
 	"github.com/kuberhealthy/kuberhealthy/v3/internal/envs"
@@ -63,7 +63,7 @@ func ReportFailure(errorMessages []string) error {
 // writeLog writes a log entry if debugging is enabled
 func writeLog(i ...interface{}) {
 	if Debug {
-		log.Println("checkClient:", fmt.Sprint(i...))
+		log.Infoln("checkClient:", fmt.Sprint(i...))
 	}
 }
 


### PR DESCRIPTION
## Summary
- reintroduce `github.com/sirupsen/logrus` as the logging framework
- replace remaining standard library log usages across controllers and clients

## Testing
- `go test ./...` *(fails: expected status 400, got 415 in TestCheckReportHandler)*

------
https://chatgpt.com/codex/tasks/task_e_68abc23a25dc832385b671a4ffddb3c5