### PR TITLE
Expose controller metrics on main web server

### DIFF
--- a/cmd/kuberhealthy/webserver.go
+++ b/cmd/kuberhealthy/webserver.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 const statusPageHTML = `
@@ -144,6 +145,9 @@ func newServeMux() *http.ServeMux {
 			log.Errorln(err)
 		}
 	})
+
+	// expose controller-runtime metrics under /controllerMetrics
+	mux.Handle("/controllerMetrics", crmetrics.Handler())
 
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		if err := healthCheckHandler(w, r); err != nil {

--- a/internal/controller/new.go
+++ b/internal/controller/new.go
@@ -21,9 +21,11 @@ func New(ctx context.Context, cfg *rest.Config) (*KuberhealthyCheckReconciler, e
 	scheme := runtime.NewScheme()
 	utilruntime.Must(khcrdsv2.AddToScheme(scheme))
 
-	// Create a new manager
+	// Create a new manager with the default metrics server disabled.
+	// Controller metrics will be served by the web server under /controllerMetrics.
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme,
+		Scheme:             scheme,
+		MetricsBindAddress: "0", // metrics served by web server
 	})
 	if err != nil {
 		return nil, fmt.Errorf("controller: error creating manager: %w", err)


### PR DESCRIPTION
## Summary
- serve controller-runtime metrics under `/controllerMetrics` via Kuberhealthy's web server
- disable standalone controller-runtime metrics listener to avoid port conflicts

## Testing
- `go test ./...` *(fails: command hung while downloading modules)*

------
https://chatgpt.com/codex/tasks/task_e_68abc0f40ad88323b96bbcd758659673