### PR TITLE
chore: default listen port 80

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ kustomize build github.com/kuberhealthy/kuberhealthy/deploy | kubectl apply -f -
 After installation you can reach the Kuberhealthy graphical status page locally with:
 
 ```sh
-kubectl -n kuberhealthy port-forward svc/kuberhealthy 8080:8080
+kubectl -n kuberhealthy port-forward svc/kuberhealthy 8080:80
 ```
 
 Then open [http://localhost:8080](http://localhost:8080) in your browser.

--- a/cmd/kuberhealthy/README.md
+++ b/cmd/kuberhealthy/README.md
@@ -12,7 +12,7 @@
 
 # Environment Variables
 ```
-KH_LISTEN_ADDRESS=":8080" # web server listen address
+KH_LISTEN_ADDRESS=":80" # web server listen address
 KH_LOG_LEVEL="info" # log verbosity
 KH_MAX_JOB_AGE="" # max age for check jobs
 KH_MAX_CHECK_POD_AGE="" # max age for check pods

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         imagePullPolicy: Never
         env:
         - name: KH_LISTEN_ADDRESS
-          value: ":8080"
+          value: ":80"
         - name: KH_LOG_LEVEL
           value: "info"
         - name: KH_MAX_JOB_AGE
@@ -60,4 +60,5 @@ spec:
         - name: KH_DEFAULT_NAMESPACE
           value: "kuberhealthy"
         ports:
+        - containerPort: 80
         - containerPort: 8080

--- a/deploy/ingress/ingress.yaml
+++ b/deploy/ingress/ingress.yaml
@@ -13,4 +13,4 @@ spec:
           service:
             name: kuberhealthy
             port:
-              number: 8080
+              number: 80

--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -6,7 +6,7 @@ Kuberhealthy is configured via environment variables and does not accept command
 
 | Variable | Description | Default |
 | -------- | ----------- | ------- |
-| `KH_LISTEN_ADDRESS` | Address for the web server | `:8080` |
+| `KH_LISTEN_ADDRESS` | Address for the web server | `:80` |
 | `KH_LOG_LEVEL` | Log level (trace, debug, info, warn, error, fatal, panic) | `info` |
 | `KH_MAX_JOB_AGE` | Maximum age for check jobs before cleanup | unset |
 | `KH_MAX_CHECK_POD_AGE` | Maximum age for check pods before cleanup | unset |


### PR DESCRIPTION
## Summary
- switch default listen address to port 80 in deployment
- update docs and examples to reflect port 80

## Testing
- `go test ./...` *(fails: command hung without completing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac018ec4388323bc18a71e1fb014c2