### PR TITLE
Fix logging levels for API warnings

### DIFF
--- a/cmd/kuberhealthy/config.go
+++ b/cmd/kuberhealthy/config.go
@@ -147,7 +147,7 @@ func (c *Config) LoadFromEnv() error {
 		c.checkReportURL = v
 	} else {
 		c.checkReportURL = fmt.Sprintf("%s.%s.svc.cluster.local", c.ServiceName, c.Namespace)
-		log.Infoln("KH_CHECK_REPORT_HOSTNAME environment variable not set. Using", c.checkReportURL)
+		log.Warnln("KH_CHECK_REPORT_HOSTNAME environment variable not set. Using", c.checkReportURL)
 	}
 
 	if v := os.Getenv("KH_TERMINATION_GRACE_PERIOD"); v != "" {

--- a/cmd/kuberhealthy/util.go
+++ b/cmd/kuberhealthy/util.go
@@ -78,7 +78,7 @@ func GetMyNamespace(defaultNamespace string) string {
 		log.Infoln("Found instance namespace:", string(data))
 		instanceNamespace = instanceNamespaceEnv
 	} else {
-		log.Infoln("Did not find instance namespace. Using default namespace:", defaultNamespace)
+		log.Warnln("Did not find instance namespace. Using default namespace:", defaultNamespace)
 	}
 
 	return instanceNamespace

--- a/cmd/kuberhealthy/webserver.go
+++ b/cmd/kuberhealthy/webserver.go
@@ -1022,7 +1022,7 @@ func storeCheckState(checkName string, checkNamespace string, khcheck *kuberheal
 		if tries > maxTries {
 			return fmt.Errorf("failed to update khcheck status for check %s in namespace %s after %d with error %w", checkName, checkNamespace, maxTries, err)
 		}
-		log.Infoln("Failed to update khcheck status because object was modified by another process.  Retrying in " + delay.String() + ".  Try " + strconv.Itoa(tries) + " of " + strconv.Itoa(maxTries) + ".")
+		log.Warnln("Failed to update khcheck status because object was modified by another process.  Retrying in " + delay.String() + ".  Try " + strconv.Itoa(tries) + " of " + strconv.Itoa(maxTries) + ".")
 
 		// sleep and double the delay between checks (exponential backoff)
 		time.Sleep(delay)

--- a/pkg/logruslogr/logruslogr.go
+++ b/pkg/logruslogr/logruslogr.go
@@ -33,6 +33,10 @@ func (s *sink) Info(level int, msg string, kv ...interface{}) {
 	if s.name != "" {
 		entry = entry.WithField("logger", s.name)
 	}
+	if s.name == "KubeAPIWarningLogger" {
+		entry.Warn(msg)
+		return
+	}
 	if level > 0 {
 		entry.Debug(msg)
 		return


### PR DESCRIPTION
## Summary
- log KubeAPI warnings as warnings
- warn when status updates are retried
- warn when instance namespace or check report hostname env vars are missing

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ac18a9573483238adba785acdeb4a7