### PR TITLE
docs: use markdown logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-<center><img src="https://github.com/kuberhealthy/kuberhealthy/blob/master/images/kuberhealthy.png?raw=true"></center><br />
+![Kuberhealthy Logo](images/kuberhealthy.png)
 
 **Kuberhealthy is a [Kubernetes](https://kubernetes.io) [operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) for [synthetic monitoring](https://en.wikipedia.org/wiki/Synthetic_monitoring) and [continuous process verification](https://en.wikipedia.org/wiki/Continued_process_verification).**  [Write your own tests](docs/CHECK_CREATION.md) in any language and Kuberhealthy will run them for you.  Automatically creates metrics for [Prometheus](https://prometheus.io).  Includes simple JSON status page.  **Now part of the CNCF!**
 


### PR DESCRIPTION
## Summary
- replace HTML logo block with Markdown image using relative path

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ad6d237d108323b6d2306cd2c5a6b9