### PR TITLE
docs: drop influxdb references

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Kuberhealthy lets you continuously verify that your applications and Kubernetes 
 
 Kuberhealthy comes with [lots of useful checks already available](docs/CHECKS_REGISTRY.md) to ensure the core functionality of Kubernetes, but checks can be used to test anything you like.  We encourage you to [write your own check container](docs/CHECK_CREATION.md) in any language to test your own applications.  It really is quick and easy!
 
-Kuberhealthy serves the status of all checks on a simple JSON status page, a [Prometheus](https://prometheus.io/) metrics endpoint (at `/metrics`), and supports InfluxDB metric forwarding for integration into your choice of alerting solution. The OpenAPI specification for the API is available as JSON at `/openapi.yaml` and `/openapi.json` on the web server.
+Kuberhealthy serves the status of all checks on a simple JSON status page and a [Prometheus](https://prometheus.io/) metrics endpoint (at `/metrics`). The OpenAPI specification for the API is available as JSON at `/openapi.yaml` and `/openapi.json` on the web server.
 
 
 


### PR DESCRIPTION
## Summary
- remove mention of InfluxDB metric forwarding from README

## Testing
- `go test ./...` *(fails: command hung without output and was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6c9c1b588323b02a312d523f9c6f