### PR TITLE
Fix khcheck pod owner reference GVK

### DIFF
--- a/internal/kuberhealthy/kuberhealthy.go
+++ b/internal/kuberhealthy/kuberhealthy.go
@@ -257,7 +257,7 @@ func (kh *Kuberhealthy) CheckPodSpec(khcheck *khcrdsv2.KuberhealthyCheck) *corev
 			Annotations: map[string]string{},
 			Labels:      map[string]string{},
 			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(khcheck, khcheck.GroupVersionKind()),
+				*metav1.NewControllerRef(khcheck, khcrdsv2.GroupVersion.WithKind("KuberhealthyCheck")),
 			},
 		},
 		Spec: khcheck.Spec.PodSpec.Spec,

--- a/internal/kuberhealthy/kuberhealthy_test.go
+++ b/internal/kuberhealthy/kuberhealthy_test.go
@@ -21,10 +21,6 @@ func TestCheckPodSpec(t *testing.T) {
 	kh := New(context.Background(), nil)
 
 	check := &khcrdsv2.KuberhealthyCheck{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "kuberhealthy.github.io/v2",
-			Kind:       "KuberhealthyCheck",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-check",
 			Namespace: "example-ns",
@@ -58,6 +54,8 @@ func TestCheckPodSpec(t *testing.T) {
 	owner := pod.OwnerReferences[0]
 	require.Equal(t, check.Name, owner.Name)
 	require.Equal(t, check.UID, owner.UID)
+	require.Equal(t, khcrdsv2.GroupVersion.String(), owner.APIVersion)
+	require.Equal(t, "KuberhealthyCheck", owner.Kind)
 	require.NotNil(t, owner.Controller)
 	require.True(t, *owner.Controller)
 }


### PR DESCRIPTION
## Summary
- ensure khcheck pod owner references use explicit GroupVersionKind
- test owner reference includes APIVersion and Kind even without TypeMeta

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ad6cde5f20832382b2f47f64d17fec