### PR TITLE
docs: add deployment verification instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,18 @@ Kuberhealthy is configured entirely with environment variables. The deployment m
 
 You can see checks that are configured with `kubectl -n kuberhealthy get khcheck`. Check status can be accessed via the JSON status page endpoint or by inspecting the status field on the `khcheck` resource.
 
+#### Verify Deployment
+
+After installation, verify that Kuberhealthy is running and serving metrics:
+
+```sh
+kubectl get pods -n kuberhealthy
+kubectl -n kuberhealthy port-forward svc/kuberhealthy 8080:80 &
+curl -f localhost:8080/metrics
+```
+
+The `kuberhealthy` pod should be in a `Running` state and the metrics endpoint should respond. If checks fail, consult the [troubleshooting guide](docs/TROUBLESHOOTING.md).
+
 
 ### Further Configuration
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,21 @@
+# Troubleshooting
+
+If Kuberhealthy checks are failing:
+
+- Ensure the operator pod is running:
+  ```sh
+  kubectl get pods -n kuberhealthy
+  ```
+- Inspect logs for errors:
+  ```sh
+  kubectl logs -n kuberhealthy deployment/kuberhealthy
+  ```
+- Review `khcheck` resources for detailed error messages:
+  ```sh
+  kubectl get khcheck -n kuberhealthy -o yaml
+  ```
+- Confirm the status page and metrics endpoint are reachable:
+  ```sh
+  kubectl -n kuberhealthy port-forward svc/kuberhealthy 8080:80
+  curl -f localhost:8080/metrics
+  ```


### PR DESCRIPTION
## Summary
- add deployment verification steps to README
- document troubleshooting steps for failing checks

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ad6d6624f48323942584988125b8b6