### PR TITLE
refactor controller watchers

### DIFF
--- a/cmd/kuberhealthy/main.go
+++ b/cmd/kuberhealthy/main.go
@@ -29,7 +29,7 @@ var GlobalConfig *Config
 var (
 	kubeConfig   *rest.Config
 	kubeClient   kubernetes.Interface
-	KHController *controller.KuberhealthyCheckReconciler
+	KHController *controller.KHCheckController
 )
 
 func main() {

--- a/cmd/kuberhealthy/metrics_handler_test.go
+++ b/cmd/kuberhealthy/metrics_handler_test.go
@@ -27,7 +27,7 @@ func TestPrometheusMetricsEndpoint(t *testing.T) {
 		t.Fatalf("failed to add scheme: %v", err)
 	}
 	fakeClient := fake.NewClientBuilder().WithScheme(s).Build()
-	KHController = &controller.KuberhealthyCheckReconciler{Client: fakeClient}
+	KHController = &controller.KHCheckController{Client: fakeClient}
 	GlobalConfig = &Config{}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/kuberhealthy/store_check_state_test.go
+++ b/cmd/kuberhealthy/store_check_state_test.go
@@ -52,7 +52,7 @@ func TestStoreCheckStateRetriesOnConflict(t *testing.T) {
 
 	origController := KHController
 	t.Cleanup(func() { KHController = origController })
-	KHController = &controller.KuberhealthyCheckReconciler{Client: cc}
+	KHController = &controller.KHCheckController{Client: cc}
 
 	status := &kuberhealthycheckv2.KuberhealthyCheckStatus{OK: true}
 	if err := storeCheckState("conflict-check", "default", status); err != nil {

--- a/internal/controller/khCheckController.go
+++ b/internal/controller/khCheckController.go
@@ -1,0 +1,173 @@
+package controller
+
+import (
+	"context"
+	"time"
+
+	khcrdsv2 "github.com/kuberhealthy/crds/api/v2"
+	"github.com/kuberhealthy/kuberhealthy/v3/internal/kuberhealthy"
+	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	dynamicinformer "k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// KHCheckController watches KuberhealthyCheck resources and reconciles them.
+type KHCheckController struct {
+	client.Client
+	scheme       *runtime.Scheme
+	Kuberhealthy *kuberhealthy.Kuberhealthy
+	informer     cache.SharedIndexInformer
+	queue        workqueue.RateLimitingInterface
+}
+
+// newKHCheckController creates a KHCheckController with an informer watching KuberhealthyCheck resources.
+func newKHCheckController(cfg *rest.Config, cl client.Client, scheme *runtime.Scheme) (*KHCheckController, error) {
+	dyn, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	gvr := schema.GroupVersionResource{Group: "kuberhealthy.kuberhealthy.github.io", Version: "v2", Resource: "kuberhealthychecks"}
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dyn, 0, metav1.NamespaceAll, nil)
+	inf := factory.ForResource(gvr).Informer()
+
+	c := &KHCheckController{
+		Client:   cl,
+		scheme:   scheme,
+		informer: inf,
+		queue:    workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+	}
+
+	inf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.enqueue,
+		UpdateFunc: func(_, newObj interface{}) { c.enqueue(newObj) },
+		DeleteFunc: c.enqueue,
+	})
+
+	c.setupWithManager()
+
+	return c, nil
+}
+
+// Start begins running the informer and worker loops.
+func (c *KHCheckController) Start(ctx context.Context) {
+	go c.informer.Run(ctx.Done())
+	if !cache.WaitForCacheSync(ctx.Done(), c.informer.HasSynced) {
+		log.Error("controller: cache sync failed")
+		return
+	}
+	go wait.UntilWithContext(ctx, c.runWorker, time.Second)
+}
+
+func (c *KHCheckController) runWorker(ctx context.Context) {
+	for c.processNextItem(ctx) {
+	}
+}
+
+func (c *KHCheckController) processNextItem(ctx context.Context) bool {
+	obj, shutdown := c.queue.Get()
+	if shutdown {
+		return false
+	}
+	defer c.queue.Done(obj)
+
+	req, ok := obj.(ctrl.Request)
+	if !ok {
+		c.queue.Forget(obj)
+		return true
+	}
+
+	if _, err := c.Reconcile(ctx, req); err != nil {
+		c.queue.AddRateLimited(req)
+	} else {
+		c.queue.Forget(obj)
+	}
+	return true
+}
+
+func (c *KHCheckController) enqueue(obj interface{}) {
+	if obj == nil {
+		return
+	}
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+	if m, ok := obj.(metav1.Object); ok {
+		req := ctrl.Request{NamespacedName: types.NamespacedName{Name: m.GetName(), Namespace: m.GetNamespace()}}
+		c.queue.Add(req)
+	}
+}
+
+// sanitizeCheck resets metadata fields that should not be sent back to the API server.
+func sanitizeCheck(check *khcrdsv2.KuberhealthyCheck) {
+	check.ObjectMeta.ManagedFields = nil
+	check.ObjectMeta.UID = ""
+}
+
+// Reconcile mirrors KuberhealthyCheckReconciler.Reconcile.
+func (c *KHCheckController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log.Debugln("controller: Reconcile")
+
+	var check khcrdsv2.KuberhealthyCheck
+	if err := c.Client.Get(ctx, req.NamespacedName, &check); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	finalizer := "kuberhealthy.github.io/finalizer"
+
+	if !check.ObjectMeta.DeletionTimestamp.IsZero() {
+		if controllerutil.ContainsFinalizer(&check, finalizer) {
+			log.Infoln("controller: FINALIZER DELETE event detected for:", req.Namespace+"/"+req.Name)
+			retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				if err := c.Client.Get(ctx, req.NamespacedName, &check); err != nil {
+					return err
+				}
+				controllerutil.RemoveFinalizer(&check, finalizer)
+				sanitizeCheck(&check)
+				return c.Client.Update(ctx, &check)
+			})
+			if retryErr != nil {
+				return ctrl.Result{}, retryErr
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if !controllerutil.ContainsFinalizer(&check, finalizer) {
+		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			if err := c.Client.Get(ctx, req.NamespacedName, &check); err != nil {
+				return err
+			}
+			controllerutil.AddFinalizer(&check, finalizer)
+			sanitizeCheck(&check)
+			return c.Client.Update(ctx, &check)
+		})
+		if retryErr != nil {
+			return ctrl.Result{}, retryErr
+		}
+	}
+
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := c.Client.Get(ctx, req.NamespacedName, &check); err != nil {
+			return err
+		}
+		sanitizeCheck(&check)
+		return c.Client.Status().Update(ctx, &check)
+	}); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/internal/controller/khCheckController_test.go
+++ b/internal/controller/khCheckController_test.go
@@ -1,0 +1,79 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	khcrdsv2 "github.com/kuberhealthy/crds/api/v2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// conflictClient simulates a conflict on the first status update call.
+type conflictClient struct {
+	client.Client
+	calls int
+}
+
+func (c *conflictClient) Status() client.StatusWriter {
+	return &conflictStatusWriter{StatusWriter: c.Client.Status(), parent: c}
+}
+
+type conflictStatusWriter struct {
+	client.StatusWriter
+	parent *conflictClient
+}
+
+func (w *conflictStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	w.parent.calls++
+	if w.parent.calls == 1 {
+		return apierrors.NewConflict(schema.GroupResource{Group: "kuberhealthy.kuberhealthy.github.io", Resource: "kuberhealthychecks"}, obj.GetName(), fmt.Errorf("conflict"))
+	}
+	return w.StatusWriter.Update(ctx, obj, opts...)
+}
+
+func TestEnqueueAddsRequest(t *testing.T) {
+	t.Parallel()
+	c := &KHCheckController{queue: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())}
+	obj := &khcrdsv2.KuberhealthyCheck{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"}}
+	c.enqueue(obj)
+	if c.queue.Len() != 1 {
+		t.Fatalf("expected queue length 1 got %d", c.queue.Len())
+	}
+}
+
+func TestReconcileRetriesOnConflict(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	if err := khcrdsv2.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add scheme: %v", err)
+	}
+	check := &khcrdsv2.KuberhealthyCheck{ObjectMeta: metav1.ObjectMeta{Name: "conflict", Namespace: "ns"}}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(check).WithStatusSubresource(check).Build()
+	cc := &conflictClient{Client: fakeClient}
+	controller := &KHCheckController{Client: cc}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "conflict", Namespace: "ns"}}
+	if _, err := controller.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("reconcile returned error: %v", err)
+	}
+	if cc.calls < 2 {
+		t.Fatalf("expected at least 2 status update calls, got %d", cc.calls)
+	}
+}
+
+func TestSanitizeCheck(t *testing.T) {
+	t.Parallel()
+	check := &khcrdsv2.KuberhealthyCheck{ObjectMeta: metav1.ObjectMeta{UID: "abc", ResourceVersion: "1", ManagedFields: []metav1.ManagedFieldsEntry{{}}}}
+	sanitizeCheck(check)
+	if check.ObjectMeta.UID != "" || check.ObjectMeta.ManagedFields != nil {
+		t.Fatalf("sanitizeCheck did not clear metadata fields")
+	}
+}

--- a/internal/controller/new.go
+++ b/internal/controller/new.go
@@ -11,57 +11,42 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // New creates a new KuberhealthyCheckReconciler with a working controller manager from the kubebuilder packages.
 // Expects a kuberhealthy.Kuberhealthy. If it is not started, then this function will start it.
-func New(ctx context.Context, cfg *rest.Config) (*KuberhealthyCheckReconciler, error) {
+func New(ctx context.Context, cfg *rest.Config) (*KHCheckController, error) {
 	log.Debugln("controller: starting new Kuberhealthy Controller")
 
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(khcrdsv2.AddToScheme(scheme))
 
-	// Create a new manager with the default metrics server disabled.
-	// Controller metrics will be served by the web server under /controllerMetrics.
-	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme,
-	})
+	cl, err := client.New(cfg, client.Options{Scheme: scheme})
 	if err != nil {
-		return nil, fmt.Errorf("controller: error creating manager: %w", err)
+		return nil, fmt.Errorf("controller: error creating client: %w", err)
 	}
 
 	// make a new Kuberhealthy instance
-	kh := kuberhealthy.New(ctx, mgr.GetClient())
+	kh := kuberhealthy.New(ctx, cl)
 
-	// Create and register the reconciler
-	reconciler := &KuberhealthyCheckReconciler{
-		Client:       mgr.GetClient(),
-		Scheme:       scheme,
-		Kuberhealthy: kh,
+	// Create the KHCheck controller
+	khController, err := newKHCheckController(cfg, cl, scheme)
+	if err != nil {
+		return nil, fmt.Errorf("controller: error creating custom controller: %w", err)
 	}
+	khController.Kuberhealthy = kh
 
-	// Set the Kuberhealthy client and start it
+	// Start Kuberhealthy if needed
 	if !kh.IsStarted() {
-		err := kh.Start(ctx)
-		if err != nil {
+		if err := kh.Start(ctx); err != nil {
 			return nil, fmt.Errorf("controller: error starting kuberhealthy: %w", err)
 		}
 	}
 
-	// Start the reconciler (controller)
-	if err := reconciler.setupWithManager(mgr); err != nil {
-		return nil, fmt.Errorf("controller: error setting up controller with manager: %w", err)
-	}
+	// Start the controller
+	go khController.Start(ctx)
 
-	// Start the manager with our reconciler in it
-	go func() {
-		err = mgr.Start(ctx)
-		if err != nil {
-			log.Fatalln("fatal controller error:", err)
-		}
-	}()
-
-	return reconciler, nil
+	return khController, nil
 }


### PR DESCRIPTION
## Summary
- replace manager-based event filters with client-go informer handlers
- connect KHCheckController to new handlers for start, update, and stop

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ad6d047a288323b4e4b47c0aed6ce2