### PR TITLE
Fix kuberhealthycheck group

### DIFF
--- a/internal/controller/khCheckController.go
+++ b/internal/controller/khCheckController.go
@@ -39,7 +39,7 @@ func newKHCheckController(cfg *rest.Config, cl client.Client, scheme *runtime.Sc
 		return nil, err
 	}
 
-	gvr := schema.GroupVersionResource{Group: "kuberhealthy.kuberhealthy.github.io", Version: "v2", Resource: "kuberhealthychecks"}
+	gvr := schema.GroupVersionResource{Group: "kuberhealthy.github.io", Version: "v2", Resource: "kuberhealthychecks"}
 	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dyn, 0, metav1.NamespaceAll, nil)
 	inf := factory.ForResource(gvr).Informer()
 

--- a/internal/controller/khCheckController_test.go
+++ b/internal/controller/khCheckController_test.go
@@ -35,7 +35,7 @@ type conflictStatusWriter struct {
 func (w *conflictStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
 	w.parent.calls++
 	if w.parent.calls == 1 {
-		return apierrors.NewConflict(schema.GroupResource{Group: "kuberhealthy.kuberhealthy.github.io", Resource: "kuberhealthychecks"}, obj.GetName(), fmt.Errorf("conflict"))
+		return apierrors.NewConflict(schema.GroupResource{Group: "kuberhealthy.github.io", Resource: "kuberhealthychecks"}, obj.GetName(), fmt.Errorf("conflict"))
 	}
 	return w.StatusWriter.Update(ctx, obj, opts...)
 }

--- a/internal/controller/kuberhealthycheck_controller.go
+++ b/internal/controller/kuberhealthycheck_controller.go
@@ -37,9 +37,9 @@ type KuberhealthyCheckReconciler struct {
 	Kuberhealthy *kuberhealthy.Kuberhealthy
 }
 
-// +kubebuilder:rbac:groups=kuberhealthy.kuberhealthy.github.io,resources=kuberhealthychecks,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=kuberhealthy.kuberhealthy.github.io,resources=kuberhealthychecks/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=kuberhealthy.kuberhealthy.github.io,resources=kuberhealthychecks/finalizers,verbs=update
+// +kubebuilder:rbac:groups=kuberhealthy.github.io,resources=kuberhealthychecks,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=kuberhealthy.github.io,resources=kuberhealthychecks/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=kuberhealthy.github.io,resources=kuberhealthychecks/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
## Summary
- watch the kuberhealthycheck CRD using the correct API group
- update kubebuilder RBAC annotations to the proper group
- fix unit tests for the updated CRD group

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ae956840548323a3dae99fa208d6bf