### PR TITLE
refactor: drop pod name from check status

### DIFF
--- a/internal/kuberhealthy/kuberhealthy.go
+++ b/internal/kuberhealthy/kuberhealthy.go
@@ -515,13 +515,5 @@ func (k *Kuberhealthy) getCurrentUUID(checkName types.NamespacedName) (string, e
 		return "", fmt.Errorf("failed to get check: %w", err)
 	}
 
-	if khCheck.CurrentUUID() == "" {
-		khCheck.SetCurrentUUID(uuid.NewString())
-		err = k.CheckClient.Status().Update(k.Context, khCheck)
-		if err != nil {
-			return "", fmt.Errorf("failed to update check with fresh uuid: %w", err)
-		}
-	}
-
 	return khCheck.CurrentUUID(), nil
 }

--- a/internal/kuberhealthy/kuberhealthy.go
+++ b/internal/kuberhealthy/kuberhealthy.go
@@ -452,14 +452,31 @@ func (k *Kuberhealthy) setFreshUUID(checkName types.NamespacedName) error {
 	return nil
 }
 
-// setOK sets the OK property on the status of a khcheck
-func (k *Kuberhealthy) setOK(checkName types.NamespacedName, ok bool) error {
+// setOK marks the check status as OK
+func (k *Kuberhealthy) setOK(checkName types.NamespacedName) error {
 	khCheck, err := k.getCheck(checkName)
 	if err != nil {
 		return fmt.Errorf("failed to get check: %w", err)
 	}
 
-	khCheck.Status.OK = ok
+	khCheck.Status.OK = true
+
+	err = k.CheckClient.Status().Update(k.Context, khCheck)
+	if err != nil {
+		return fmt.Errorf("failed to update OK status: %w", err)
+	}
+
+	return nil
+}
+
+// setNotOK marks the check status as not OK
+func (k *Kuberhealthy) setNotOK(checkName types.NamespacedName) error {
+	khCheck, err := k.getCheck(checkName)
+	if err != nil {
+		return fmt.Errorf("failed to get check: %w", err)
+	}
+
+	khCheck.Status.OK = false
 
 	err = k.CheckClient.Status().Update(k.Context, khCheck)
 	if err != nil {

--- a/internal/kuberhealthy/kuberhealthy.go
+++ b/internal/kuberhealthy/kuberhealthy.go
@@ -28,6 +28,8 @@ const (
 	defaultRunInterval = time.Minute * 10
 	// scheduleLoopInterval controls how often Kuberhealthy scans for checks to run.
 	scheduleLoopInterval = 30 * time.Second
+	checkLabel           = "khcheck"
+	runUUIDLabel         = "kh-run-uuid"
 )
 
 // Kuberhealthy handles background processing for checks
@@ -204,6 +206,11 @@ func (kh *Kuberhealthy) StartCheck(khcheck *khapi.KuberhealthyCheck) error {
 	if err := kh.setFreshUUID(checkName); err != nil {
 		return fmt.Errorf("unable to set running UUID: %w", err)
 	}
+	uuid, err := kh.getCurrentUUID(checkName)
+	if err != nil {
+		return fmt.Errorf("unable to fetch running UUID: %w", err)
+	}
+	khcheck.Status.CurrentUUID = uuid
 
 	// record the start time
 	startTime := time.Now()
@@ -227,14 +234,6 @@ func (kh *Kuberhealthy) StartCheck(khcheck *khapi.KuberhealthyCheck) error {
 	}
 	if kh.Recorder != nil {
 		kh.Recorder.Eventf(khcheck, corev1.EventTypeNormal, "PodCreated", "created pod %s", podSpec.Name)
-	}
-
-	// write the name of the pod to the khcheck CRD's status
-	if err := kh.setCheckPodName(checkName, podSpec.Name); err != nil {
-		if kh.Recorder != nil {
-			kh.Recorder.Event(khcheck, corev1.EventTypeWarning, "SetPodNameFailed", fmt.Sprintf("unable to set pod name: %v", err))
-		}
-		return fmt.Errorf("unable to set check pod name: %w", err)
 	}
 	return nil
 }
@@ -270,7 +269,8 @@ func (kh *Kuberhealthy) CheckPodSpec(khcheck *khapi.KuberhealthyCheck) *corev1.P
 	podSpec.Annotations["createdTime"] = time.Unix(khcheck.Status.LastRunUnix, 0).String()
 
 	// add required labels
-	podSpec.Labels["khcheck"] = khcheck.Name
+	podSpec.Labels[checkLabel] = khcheck.Name
+	podSpec.Labels[runUUIDLabel] = khcheck.Status.CurrentUUID
 
 	return podSpec
 }
@@ -296,48 +296,25 @@ func (kh *Kuberhealthy) StopCheck(khcheck *khapi.KuberhealthyCheck) error {
 		return err
 	}
 
-	// fetch the current running pod's name
-	podName, err := kh.getCurrentPodName(khcheck)
+	var podList corev1.PodList
+	err = kh.CheckClient.List(kh.Context, &podList,
+		client.InNamespace(khcheck.GetNamespace()),
+		client.MatchingLabels(map[string]string{checkLabel: khcheck.Name}),
+	)
 	if err != nil {
-		return fmt.Errorf("failed to get check status for cleanup: %w", err)
+		return fmt.Errorf("failed to list check pods: %w", err)
 	}
-
-	// if the pod name is not set, we have nothing to do
-	if podName == "" {
-		return nil
-	}
-
-	// delete the checker pod
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: khcheck.GetNamespace(),
-			Name:      podName,
-		},
-	}
-	if err := kh.CheckClient.Delete(kh.Context, pod); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to delete checker pod %s: %w", podName, err)
+	for i := range podList.Items {
+		podRef := &podList.Items[i]
+		uuid := podRef.Labels[runUUIDLabel]
+		if uuid != "" && khcheck.Status.CurrentUUID != "" && uuid != khcheck.Status.CurrentUUID {
+			continue
+		}
+		if err := kh.CheckClient.Delete(kh.Context, podRef); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete checker pod %s: %w", podRef.Name, err)
 		}
 	}
-	// clear stored pod name in status
-	if err := kh.setCheckPodName(checkName, ""); err != nil {
-		return fmt.Errorf("failed to clear checker pod name: %w", err)
-	}
-
 	return nil
-}
-
-// getCurrentPodName fetches the current pod's name for the provided khcheck from the control plane
-func (kh *Kuberhealthy) getCurrentPodName(khcheck *khapi.KuberhealthyCheck) (string, error) {
-	namespacedName := types.NamespacedName{
-		Namespace: khcheck.GetNamespace(),
-		Name:      khcheck.GetName(),
-	}
-	check, err := kh.getCheck(namespacedName)
-	if err != nil {
-		return "", fmt.Errorf("failed to get check status for cleanup: %w", err)
-	}
-	return check.Status.PodName, nil
 }
 
 // UpdateCheck handles the event of a check getting updated in place
@@ -533,19 +510,6 @@ func (k *Kuberhealthy) setRunDuration(checkName types.NamespacedName, runDuratio
 		return fmt.Errorf("failed to update RunDuration: %w", err)
 	}
 
-	return nil
-}
-
-// setCheckPodName writes the name of the recently created checker pod to the check's status
-func (k *Kuberhealthy) setCheckPodName(checkName types.NamespacedName, podName string) error {
-	khCheck, err := k.getCheck(checkName)
-	if err != nil {
-		return fmt.Errorf("failed to get check: %w", err)
-	}
-	khCheck.Status.PodName = podName
-	if err := k.CheckClient.Status().Update(k.Context, khCheck); err != nil {
-		return fmt.Errorf("failed to update check pod name: %w", err)
-	}
 	return nil
 }
 

--- a/internal/kuberhealthy/kuberhealthy_test.go
+++ b/internal/kuberhealthy/kuberhealthy_test.go
@@ -97,7 +97,7 @@ func TestSetFreshUUID(t *testing.T) {
 
 	fetched, err := kh.getCheck(nn)
 	require.NoError(t, err)
-	require.NotEmpty(t, fetched.Status.CurrentUUID)
+	require.NotEmpty(t, fetched.CurrentUUID())
 }
 
 func TestScheduleStartsCheck(t *testing.T) {
@@ -132,7 +132,7 @@ func TestScheduleStartsCheck(t *testing.T) {
 
 	fetched := &khapi.KuberhealthyCheck{}
 	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: "sched-check", Namespace: "default"}, fetched))
-	require.NotEmpty(t, fetched.Status.CurrentUUID)
+	require.NotEmpty(t, fetched.CurrentUUID())
 	require.NotZero(t, fetched.Status.LastRunUnix)
 }
 
@@ -172,7 +172,7 @@ func TestScheduleSkipsWhenNotDue(t *testing.T) {
 
 	fetched := &khapi.KuberhealthyCheck{}
 	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: "skip-check", Namespace: "default"}, fetched))
-	require.Empty(t, fetched.Status.CurrentUUID)
+	require.Empty(t, fetched.CurrentUUID())
 	require.Equal(t, last, fetched.Status.LastRunUnix)
 }
 

--- a/internal/kuberhealthy/reaper.go
+++ b/internal/kuberhealthy/reaper.go
@@ -130,7 +130,7 @@ func (kh *Kuberhealthy) reapOnce() error {
 					}
 					if uuid == check.Status.CurrentUUID {
 						_ = kh.setCheckExecutionError(checkNN, []string{"check run timed out"})
-						_ = kh.setOK(checkNN, false)
+						_ = kh.setNotOK(checkNN)
 						_ = kh.clearUUID(checkNN)
 					}
 				}

--- a/internal/kuberhealthy/reaper.go
+++ b/internal/kuberhealthy/reaper.go
@@ -129,9 +129,9 @@ func (kh *Kuberhealthy) reapOnce() error {
 						kh.Recorder.Eventf(check, corev1.EventTypeWarning, "CheckRunTimeout", "deleted pod %s after exceeding timeout %s", podRef.Name, runTimeout)
 					}
 					if uuid == check.CurrentUUID() {
-						_ = kh.setCheckExecutionError(checkNN, []string{"check run timed out"})
+						check.SetCheckExecutionError([]string{"check run timed out"})
 						check.SetNotOK()
-						if err := kh.CheckClient.Status().Update(kh.Context, check); err != nil {
+						if err := khapi.UpdateCheck(kh.Context, kh.CheckClient, check); err != nil {
 							log.Errorf("reaper: failed setting check %s/%s not OK: %v", check.Namespace, check.Name, err)
 						}
 						_ = kh.clearUUID(checkNN)

--- a/internal/kuberhealthy/reaper_test.go
+++ b/internal/kuberhealthy/reaper_test.go
@@ -32,17 +32,17 @@ func TestReaperTimesOutRunningPod(t *testing.T) {
 			ResourceVersion: "1",
 		},
 		Status: khapi.KuberhealthyCheckStatus{
-			CurrentUUID: "abc123",
 			LastRunUnix: lastRun.Unix(),
-			OK:          true,
 		},
 	}
+	check.SetCurrentUUID("abc123")
+	check.SetOK()
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "timeout-pod",
 			Namespace: "default",
-			Labels:    map[string]string{checkLabel: check.Name, runUUIDLabel: check.Status.CurrentUUID},
+			Labels:    map[string]string{checkLabel: check.Name, runUUIDLabel: check.CurrentUUID()},
 		},
 		Status: corev1.PodStatus{Phase: corev1.PodRunning},
 	}
@@ -66,7 +66,7 @@ func TestReaperTimesOutRunningPod(t *testing.T) {
 	require.False(t, updated.Status.OK)
 	require.Len(t, updated.Status.Errors, 1)
 	require.Contains(t, updated.Status.Errors[0], "timed out")
-	require.Empty(t, updated.Status.CurrentUUID)
+	require.Empty(t, updated.CurrentUUID())
 }
 
 // Test that completed pods are removed after three run intervals have passed.

--- a/pkg/api/kuberhealthycheck_types.go
+++ b/pkg/api/kuberhealthycheck_types.go
@@ -84,3 +84,23 @@ type KuberhealthyCheckList struct {
 func init() {
 	SchemeBuilder.Register(&KuberhealthyCheck{}, &KuberhealthyCheckList{})
 }
+
+// CurrentUUID returns the running UUID for this check.
+func (k *KuberhealthyCheck) CurrentUUID() string {
+	return k.Status.CurrentUUID
+}
+
+// SetCurrentUUID updates the running UUID on the check status.
+func (k *KuberhealthyCheck) SetCurrentUUID(u string) {
+	k.Status.CurrentUUID = u
+}
+
+// SetOK marks the check status as healthy.
+func (k *KuberhealthyCheck) SetOK() {
+	k.Status.OK = true
+}
+
+// SetNotOK marks the check status as unhealthy.
+func (k *KuberhealthyCheck) SetNotOK() {
+	k.Status.OK = false
+}

--- a/pkg/api/kuberhealthycheck_types.go
+++ b/pkg/api/kuberhealthycheck_types.go
@@ -17,10 +17,13 @@ limitations under the License.
 package api
 
 import (
+	"context"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -103,4 +106,33 @@ func (k *KuberhealthyCheck) SetOK() {
 // SetNotOK marks the check status as unhealthy.
 func (k *KuberhealthyCheck) SetNotOK() {
 	k.Status.OK = false
+}
+
+// SetCheckExecutionError assigns execution errors on the check status.
+func (k *KuberhealthyCheck) SetCheckExecutionError(errs []string) {
+	k.Status.Errors = errs
+}
+
+// CreateCheck writes a new check object to the cluster.
+func CreateCheck(ctx context.Context, cl client.Client, check *KuberhealthyCheck) error {
+	return cl.Create(ctx, check)
+}
+
+// GetCheck fetches the current version of a check.
+func GetCheck(ctx context.Context, cl client.Client, nn types.NamespacedName) (*KuberhealthyCheck, error) {
+	out := &KuberhealthyCheck{}
+	if err := cl.Get(ctx, nn, out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// UpdateCheck persists status changes for a check.
+func UpdateCheck(ctx context.Context, cl client.Client, check *KuberhealthyCheck) error {
+	return cl.Status().Update(ctx, check)
+}
+
+// DeleteCheck removes a check from the cluster.
+func DeleteCheck(ctx context.Context, cl client.Client, check *KuberhealthyCheck) error {
+	return cl.Delete(ctx, check)
 }

--- a/pkg/api/kuberhealthycheck_types.go
+++ b/pkg/api/kuberhealthycheck_types.go
@@ -50,8 +50,6 @@ type KuberhealthyCheckStatus struct {
 	LastRunDuration time.Duration `json:"runDuration,omitempty"`
 	// Namespace is the Kubernetes namespace this pod ran in.
 	Namespace string `json:"namespace,omitempty"`
-	// PodName is the name of the Pod that was most recently created to run this check
-	PodName string `json:"podName,omitempty"`
 	// CurrentUUID is used to ensure only the most recent checker pod reports a status for this check.
 	CurrentUUID string `json:"currentUUID,omitempty"`
 	// LastRunUnix is the last time that this check was scheduled to run.


### PR DESCRIPTION
## Summary
- remove PodName from KuberhealthyCheck status
- track checker pods via labels and UUID validation

## Testing
- `go test ./...` *(fails: command hung)*

------
https://chatgpt.com/codex/tasks/task_e_68b08530fb648323b632aea889c7b48d