### PR TITLE
refactor: drop pod name from check status

### DIFF
--- a/internal/kuberhealthy/kuberhealthy.go
+++ b/internal/kuberhealthy/kuberhealthy.go
@@ -28,6 +28,8 @@ const (
 	defaultRunInterval = time.Minute * 10
 	// scheduleLoopInterval controls how often Kuberhealthy scans for checks to run.
 	scheduleLoopInterval = 30 * time.Second
+	checkLabel           = "khcheck"
+	runUUIDLabel         = "kh-run-uuid"
 )
 
 // Kuberhealthy handles background processing for checks
@@ -166,7 +168,7 @@ func (kh *Kuberhealthy) scheduleChecks() {
 		debugKHCheckMetadata(&check)
 
 		lastStart := time.Unix(check.Status.LastRunUnix, 0)
-		if check.Status.CurrentUUID != "" {
+		if check.CurrentUUID() != "" {
 			continue
 		}
 		if time.Since(lastStart) < runInterval {
@@ -228,14 +230,6 @@ func (kh *Kuberhealthy) StartCheck(khcheck *khapi.KuberhealthyCheck) error {
 	if kh.Recorder != nil {
 		kh.Recorder.Eventf(khcheck, corev1.EventTypeNormal, "PodCreated", "created pod %s", podSpec.Name)
 	}
-
-	// write the name of the pod to the khcheck CRD's status
-	if err := kh.setCheckPodName(checkName, podSpec.Name); err != nil {
-		if kh.Recorder != nil {
-			kh.Recorder.Event(khcheck, corev1.EventTypeWarning, "SetPodNameFailed", fmt.Sprintf("unable to set pod name: %v", err))
-		}
-		return fmt.Errorf("unable to set check pod name: %w", err)
-	}
 	return nil
 }
 
@@ -248,6 +242,12 @@ func (kh *Kuberhealthy) CheckPodSpec(khcheck *khapi.KuberhealthyCheck) *corev1.P
 		suffix = suffix[:5]
 	}
 	podName := fmt.Sprintf("%s-%s", khcheck.GetName(), suffix)
+
+	checkName := types.NamespacedName{Namespace: khcheck.Namespace, Name: khcheck.Name}
+	uuid, err := kh.getCurrentUUID(checkName)
+	if err != nil {
+		log.Errorf("failed to get check uuid: %v", err)
+	}
 
 	// formulate a full pod spec
 	podSpec := &corev1.Pod{
@@ -270,7 +270,8 @@ func (kh *Kuberhealthy) CheckPodSpec(khcheck *khapi.KuberhealthyCheck) *corev1.P
 	podSpec.Annotations["createdTime"] = time.Unix(khcheck.Status.LastRunUnix, 0).String()
 
 	// add required labels
-	podSpec.Labels["khcheck"] = khcheck.Name
+	podSpec.Labels[checkLabel] = khcheck.Name
+	podSpec.Labels[runUUIDLabel] = uuid
 
 	return podSpec
 }
@@ -280,6 +281,7 @@ func (kh *Kuberhealthy) StopCheck(khcheck *khapi.KuberhealthyCheck) error {
 	log.Infoln("Stopping Kuberhealthy check", khcheck.GetNamespace(), khcheck.GetName())
 
 	// clear CurrentUUID to indicate the check is no longer running
+	oldUUID := khcheck.CurrentUUID()
 	checkName := createNamespacedName(khcheck.GetName(), khcheck.GetNamespace())
 	kh.clearUUID(checkName)
 
@@ -296,48 +298,25 @@ func (kh *Kuberhealthy) StopCheck(khcheck *khapi.KuberhealthyCheck) error {
 		return err
 	}
 
-	// fetch the current running pod's name
-	podName, err := kh.getCurrentPodName(khcheck)
-	if err != nil {
-		return fmt.Errorf("failed to get check status for cleanup: %w", err)
-	}
-
-	// if the pod name is not set, we have nothing to do
-	if podName == "" {
+	if oldUUID == "" {
 		return nil
 	}
 
-	// delete the checker pod
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: khcheck.GetNamespace(),
-			Name:      podName,
-		},
+	var podList corev1.PodList
+	err = kh.CheckClient.List(kh.Context, &podList,
+		client.InNamespace(khcheck.GetNamespace()),
+		client.MatchingLabels(map[string]string{runUUIDLabel: oldUUID}),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to list check pods: %w", err)
 	}
-	if err := kh.CheckClient.Delete(kh.Context, pod); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to delete checker pod %s: %w", podName, err)
+	for i := range podList.Items {
+		podRef := &podList.Items[i]
+		if err := kh.CheckClient.Delete(kh.Context, podRef); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete checker pod %s: %w", podRef.Name, err)
 		}
 	}
-	// clear stored pod name in status
-	if err := kh.setCheckPodName(checkName, ""); err != nil {
-		return fmt.Errorf("failed to clear checker pod name: %w", err)
-	}
-
 	return nil
-}
-
-// getCurrentPodName fetches the current pod's name for the provided khcheck from the control plane
-func (kh *Kuberhealthy) getCurrentPodName(khcheck *khapi.KuberhealthyCheck) (string, error) {
-	namespacedName := types.NamespacedName{
-		Namespace: khcheck.GetNamespace(),
-		Name:      khcheck.GetName(),
-	}
-	check, err := kh.getCheck(namespacedName)
-	if err != nil {
-		return "", fmt.Errorf("failed to get check status for cleanup: %w", err)
-	}
-	return check.Status.PodName, nil
 }
 
 // UpdateCheck handles the event of a check getting updated in place
@@ -381,72 +360,30 @@ func debugKHCheckMetadata(khCheck *khapi.KuberhealthyCheck) {
 	}).Debug("khcheck podSpec metadata")
 }
 
-// getCheck fetches a check based on its name and namespace
-func (k *Kuberhealthy) getCheck(checkName types.NamespacedName) (*khapi.KuberhealthyCheck, error) {
-	khCheck := &khapi.KuberhealthyCheck{}
-	err := k.CheckClient.Get(k.Context, checkName, khCheck)
+// readCheck fetches a check from the cluster.
+func (k *Kuberhealthy) readCheck(checkName types.NamespacedName) (*khapi.KuberhealthyCheck, error) {
+	khCheck, err := khapi.GetCheck(k.Context, k.CheckClient, checkName)
 	if err == nil {
-		// log metadata to help track unexpected fields
 		debugKHCheckMetadata(khCheck)
 	}
 	return khCheck, err
 }
-
-// setCheckExecutionError sets an execution error for a khcheck in its crd status
-func (k *Kuberhealthy) setCheckExecutionError(checkName types.NamespacedName, checkErrors []string) error {
-
-	// get the check as it is right now
-	khCheck, err := k.getCheck(checkName)
-	if err != nil {
-		return fmt.Errorf("failed to get check: %w", err)
-	}
-
-	// set the errors
-	khCheck.Status.Errors = checkErrors
-
-	// update the khcheck resource
-	err = k.CheckClient.Status().Update(k.Context, khCheck)
-	if err != nil {
-		return fmt.Errorf("failed to update check errors with error: %w", err)
-	}
-	return nil
-}
-
-// // setUUID sets the specified UUID on the check
-// func (k *Kuberhealthy) setUUID(checkName types.NamespacedName, uuid string) error {
-
-// 	// get the check as it is right now
-// 	khCheck, err := k.getCheck(checkName)
-// 	if err != nil {
-// 		return fmt.Errorf("failed to get check: %w", err)
-// 	}
-
-// 	// set the errors
-// 	khCheck.Status.CurrentUUID = uuid
-
-// 	// update the khcheck resource
-// 	err = k.CheckClient.Status().Update(k.Context, khCheck)
-// 	if err != nil {
-// 		return fmt.Errorf("failed to update check uuid with error: %w", err)
-// 	}
-// 	return nil
-// }
 
 // clearUUID clears the UUID assigned to the check, which indicates
 // that it is not running.
 func (k *Kuberhealthy) clearUUID(checkName types.NamespacedName) error {
 
 	// get the check as it is right now
-	khCheck, err := k.getCheck(checkName)
+	khCheck, err := k.readCheck(checkName)
 	if err != nil {
 		return fmt.Errorf("failed to get check: %w", err)
 	}
 
 	// set the errors
-	khCheck.Status.CurrentUUID = ""
+	khCheck.SetCurrentUUID("")
 
 	// update the khcheck resource
-	err = k.CheckClient.Status().Update(k.Context, khCheck)
+	err = khapi.UpdateCheck(k.Context, k.CheckClient, khCheck)
 	if err != nil {
 		return fmt.Errorf("failed to update check with fresh uuid with error: %w", err)
 	}
@@ -457,42 +394,25 @@ func (k *Kuberhealthy) clearUUID(checkName types.NamespacedName) error {
 func (k *Kuberhealthy) setFreshUUID(checkName types.NamespacedName) error {
 
 	// get the check as it is right now
-	khCheck, err := k.getCheck(checkName)
+	khCheck, err := k.readCheck(checkName)
 	if err != nil {
 		return fmt.Errorf("failed to get check: %w", err)
 	}
 
 	// set the errors
-	khCheck.Status.CurrentUUID = uuid.NewString()
+	khCheck.SetCurrentUUID(uuid.NewString())
 
 	// update the khcheck resource
-	err = k.CheckClient.Status().Update(k.Context, khCheck)
+	err = khapi.UpdateCheck(k.Context, k.CheckClient, khCheck)
 	if err != nil {
 		return fmt.Errorf("failed to update check with fresh uuid with error: %w", err)
 	}
 	return nil
 }
 
-// setOK sets the OK property on the status of a khcheck
-func (k *Kuberhealthy) setOK(checkName types.NamespacedName, ok bool) error {
-	khCheck, err := k.getCheck(checkName)
-	if err != nil {
-		return fmt.Errorf("failed to get check: %w", err)
-	}
-
-	khCheck.Status.OK = ok
-
-	err = k.CheckClient.Status().Update(k.Context, khCheck)
-	if err != nil {
-		return fmt.Errorf("failed to update OK status: %w", err)
-	}
-
-	return nil
-}
-
 // getLastRunTime gets the last run start time unix time
 func (k *Kuberhealthy) getLastRunTime(checkName types.NamespacedName) (time.Time, error) {
-	khCheck, err := k.getCheck(checkName)
+	khCheck, err := k.readCheck(checkName)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("failed to get check: %w", err)
 	}
@@ -504,14 +424,14 @@ func (k *Kuberhealthy) getLastRunTime(checkName types.NamespacedName) (time.Time
 
 // setLastRunTime sets the last run start time unix time
 func (k *Kuberhealthy) setLastRunTime(checkName types.NamespacedName, lastRunTime time.Time) error {
-	khCheck, err := k.getCheck(checkName)
+	khCheck, err := k.readCheck(checkName)
 	if err != nil {
 		return fmt.Errorf("failed to get check: %w", err)
 	}
 
 	khCheck.Status.LastRunUnix = lastRunTime.Unix()
 
-	err = k.CheckClient.Status().Update(k.Context, khCheck)
+	err = khapi.UpdateCheck(k.Context, k.CheckClient, khCheck)
 	if err != nil {
 		return fmt.Errorf("failed to update LastRun time: %w", err)
 	}
@@ -521,31 +441,18 @@ func (k *Kuberhealthy) setLastRunTime(checkName types.NamespacedName, lastRunTim
 
 // setRunDuration sets the time the last check took to run
 func (k *Kuberhealthy) setRunDuration(checkName types.NamespacedName, runDuration time.Duration) error {
-	khCheck, err := k.getCheck(checkName)
+	khCheck, err := k.readCheck(checkName)
 	if err != nil {
 		return fmt.Errorf("failed to get check: %w", err)
 	}
 
 	khCheck.Status.LastRunDuration = runDuration
 
-	err = k.CheckClient.Status().Update(k.Context, khCheck)
+	err = khapi.UpdateCheck(k.Context, k.CheckClient, khCheck)
 	if err != nil {
 		return fmt.Errorf("failed to update RunDuration: %w", err)
 	}
 
-	return nil
-}
-
-// setCheckPodName writes the name of the recently created checker pod to the check's status
-func (k *Kuberhealthy) setCheckPodName(checkName types.NamespacedName, podName string) error {
-	khCheck, err := k.getCheck(checkName)
-	if err != nil {
-		return fmt.Errorf("failed to get check: %w", err)
-	}
-	khCheck.Status.PodName = podName
-	if err := k.CheckClient.Status().Update(k.Context, khCheck); err != nil {
-		return fmt.Errorf("failed to update check pod name: %w", err)
-	}
 	return nil
 }
 
@@ -561,9 +468,10 @@ func (k *Kuberhealthy) isCheckRunning(checkName types.NamespacedName) (bool, err
 
 // getCurrentUUID returns the CurrentUUID string for the specified check.
 func (k *Kuberhealthy) getCurrentUUID(checkName types.NamespacedName) (string, error) {
-	khCheck, err := k.getCheck(checkName)
+	khCheck, err := k.readCheck(checkName)
 	if err != nil {
 		return "", fmt.Errorf("failed to get check: %w", err)
 	}
-	return khCheck.Status.CurrentUUID, nil
+
+	return khCheck.CurrentUUID(), nil
 }

--- a/internal/kuberhealthy/reaper.go
+++ b/internal/kuberhealthy/reaper.go
@@ -96,7 +96,7 @@ func (kh *Kuberhealthy) reapOnce() error {
 		var podList corev1.PodList
 		if err := kh.CheckClient.List(kh.Context, &podList,
 			client.InNamespace(check.Namespace),
-			client.MatchingLabels(map[string]string{"khcheck": check.Name}),
+			client.HasLabels{runUUIDLabel},
 		); err != nil {
 			log.Errorf("reaper: list pods for %s/%s: %v", check.Namespace, check.Name, err)
 			continue
@@ -113,41 +113,41 @@ func (kh *Kuberhealthy) reapOnce() error {
 		// iterate over each pod and apply retention logic based on phase
 		for pod := range podList.Items {
 			podRef := &podList.Items[pod]
+			if podRef.Labels[checkLabel] != check.Name {
+				continue
+			}
+			uuid := podRef.Labels[runUUIDLabel]
 
 			switch podRef.Status.Phase {
 			case corev1.PodRunning, corev1.PodPending, corev1.PodUnknown:
-				// terminate pods running longer than the allowed timeout
 				if runAge > runTimeout {
 					if err := kh.CheckClient.Delete(kh.Context, podRef); err != nil && !apierrors.IsNotFound(err) {
 						log.Errorf("reaper: failed deleting timed out pod %s/%s: %v", podRef.Namespace, podRef.Name, err)
 						continue
-					} else if kh.Recorder != nil {
-						// emit event when a pod is killed for timing out
+					}
+					if kh.Recorder != nil {
 						kh.Recorder.Eventf(check, corev1.EventTypeWarning, "CheckRunTimeout", "deleted pod %s after exceeding timeout %s", podRef.Name, runTimeout)
 					}
-					_ = kh.setCheckExecutionError(checkNN, []string{"check run timed out"})
-					_ = kh.setOK(checkNN, false)
-					_ = kh.clearUUID(checkNN)
-					if check.Status.PodName == podRef.Name {
-						_ = kh.setCheckPodName(checkNN, "")
+					if uuid == check.CurrentUUID() {
+						check.SetCheckExecutionError([]string{"check run timed out"})
+						check.SetNotOK()
+						if err := khapi.UpdateCheck(kh.Context, kh.CheckClient, check); err != nil {
+							log.Errorf("reaper: failed setting check %s/%s not OK: %v", check.Namespace, check.Name, err)
+						}
+						_ = kh.clearUUID(checkNN)
 					}
 				}
 			case corev1.PodSucceeded:
-				// prune successful pods after three intervals
 				if runAge > runInterval*3 {
 					if err := kh.CheckClient.Delete(kh.Context, podRef); err != nil && !apierrors.IsNotFound(err) {
 						log.Errorf("reaper: failed deleting completed pod %s/%s: %v", podRef.Namespace, podRef.Name, err)
 						continue
-					} else if kh.Recorder != nil {
-						// record cleanup of a completed pod
-						kh.Recorder.Eventf(check, corev1.EventTypeNormal, "CheckPodReaped", "deleted completed pod %s after %s", podRef.Name, runAge)
 					}
-					if check.Status.PodName == podRef.Name {
-						_ = kh.setCheckPodName(checkNN, "")
+					if kh.Recorder != nil {
+						kh.Recorder.Eventf(check, corev1.EventTypeNormal, "CheckPodReaped", "deleted completed pod %s after %s", podRef.Name, runAge)
 					}
 				}
 			case corev1.PodFailed:
-				// accumulate failed pods for later pruning
 				failedPods = append(failedPods, *podRef)
 			default:
 				log.Errorf("reaper: encountered pod %s/%s with unexpected phase %s", podRef.Namespace, podRef.Name, podRef.Status.Phase)
@@ -169,9 +169,6 @@ func (kh *Kuberhealthy) reapOnce() error {
 				} else if kh.Recorder != nil {
 					// note removal of an old failed pod
 					kh.Recorder.Eventf(check, corev1.EventTypeNormal, "CheckFailedPodReaped", "removed failed pod %s after %s", podRef.Name, runAge)
-				}
-				if check.Status.PodName == podRef.Name {
-					_ = kh.setCheckPodName(checkNN, "")
 				}
 			}
 		}

--- a/internal/kuberhealthy/reaper_test.go
+++ b/internal/kuberhealthy/reaper_test.go
@@ -32,18 +32,17 @@ func TestReaperTimesOutRunningPod(t *testing.T) {
 			ResourceVersion: "1",
 		},
 		Status: khapi.KuberhealthyCheckStatus{
-			PodName:     "timeout-pod",
-			CurrentUUID: "abc123",
 			LastRunUnix: lastRun.Unix(),
-			OK:          true,
 		},
 	}
+	check.SetCurrentUUID("abc123")
+	check.SetOK()
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "timeout-pod",
 			Namespace: "default",
-			Labels:    map[string]string{"khcheck": check.Name},
+			Labels:    map[string]string{checkLabel: check.Name, runUUIDLabel: check.CurrentUUID()},
 		},
 		Status: corev1.PodStatus{Phase: corev1.PodRunning},
 	}
@@ -67,8 +66,7 @@ func TestReaperTimesOutRunningPod(t *testing.T) {
 	require.False(t, updated.Status.OK)
 	require.Len(t, updated.Status.Errors, 1)
 	require.Contains(t, updated.Status.Errors[0], "timed out")
-	require.Empty(t, updated.Status.PodName)
-	require.Empty(t, updated.Status.CurrentUUID)
+	require.Empty(t, updated.CurrentUUID())
 }
 
 // Test that completed pods are removed after three run intervals have passed.
@@ -86,7 +84,6 @@ func TestReaperRemovesCompletedPods(t *testing.T) {
 			ResourceVersion: "1",
 		},
 		Status: khapi.KuberhealthyCheckStatus{
-			PodName:     "complete-pod",
 			LastRunUnix: lastRun.Unix(),
 		},
 	}
@@ -95,7 +92,7 @@ func TestReaperRemovesCompletedPods(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "complete-pod",
 			Namespace: "default",
-			Labels:    map[string]string{"khcheck": check.Name},
+			Labels:    map[string]string{checkLabel: check.Name, runUUIDLabel: "run-1"},
 		},
 		Status: corev1.PodStatus{Phase: corev1.PodSucceeded},
 	}
@@ -129,7 +126,6 @@ func TestReaperKeepsRecentCompletedPods(t *testing.T) {
 			ResourceVersion: "1",
 		},
 		Status: khapi.KuberhealthyCheckStatus{
-			PodName:     "recent-pod",
 			LastRunUnix: lastRun.Unix(),
 		},
 	}
@@ -138,7 +134,7 @@ func TestReaperKeepsRecentCompletedPods(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "recent-pod",
 			Namespace: "default",
-			Labels:    map[string]string{"khcheck": check.Name},
+			Labels:    map[string]string{checkLabel: check.Name, runUUIDLabel: "run-2"},
 		},
 		Status: corev1.PodStatus{Phase: corev1.PodSucceeded},
 	}
@@ -182,7 +178,7 @@ func TestReaperPrunesFailedPods(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "failed-oldest",
 				Namespace: "default",
-				Labels:    map[string]string{"khcheck": check.Name},
+				Labels:    map[string]string{checkLabel: check.Name, runUUIDLabel: "run-a"},
 			},
 			Status: corev1.PodStatus{Phase: corev1.PodFailed},
 		},
@@ -190,7 +186,7 @@ func TestReaperPrunesFailedPods(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "failed-middle",
 				Namespace: "default",
-				Labels:    map[string]string{"khcheck": check.Name},
+				Labels:    map[string]string{checkLabel: check.Name, runUUIDLabel: "run-b"},
 			},
 			Status: corev1.PodStatus{Phase: corev1.PodFailed},
 		},
@@ -198,7 +194,7 @@ func TestReaperPrunesFailedPods(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "failed-newest",
 				Namespace: "default",
-				Labels:    map[string]string{"khcheck": check.Name},
+				Labels:    map[string]string{checkLabel: check.Name, runUUIDLabel: "run-c"},
 			},
 			Status: corev1.PodStatus{Phase: corev1.PodFailed},
 		},
@@ -216,8 +212,14 @@ func TestReaperPrunesFailedPods(t *testing.T) {
 	require.NoError(t, kh.reapOnce())
 
 	var remaining corev1.PodList
-	require.NoError(t, cl.List(context.Background(), &remaining, client.InNamespace("default"), client.MatchingLabels(map[string]string{"khcheck": check.Name})))
-	require.Len(t, remaining.Items, 2)
+	require.NoError(t, cl.List(context.Background(), &remaining, client.InNamespace("default"), client.HasLabels{runUUIDLabel}))
+	var ours []corev1.Pod
+	for i := range remaining.Items {
+		if remaining.Items[i].Labels[checkLabel] == check.Name {
+			ours = append(ours, remaining.Items[i])
+		}
+	}
+	require.Len(t, ours, 2)
 }
 
 // Test that failed pods within retention limits are preserved.
@@ -245,7 +247,7 @@ func TestReaperRetainsFailedPodsWithinRetention(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "failed-one",
 				Namespace: "default",
-				Labels:    map[string]string{"khcheck": check.Name},
+				Labels:    map[string]string{checkLabel: check.Name, runUUIDLabel: "run-1"},
 			},
 			Status: corev1.PodStatus{Phase: corev1.PodFailed},
 		},
@@ -253,7 +255,7 @@ func TestReaperRetainsFailedPodsWithinRetention(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "failed-two",
 				Namespace: "default",
-				Labels:    map[string]string{"khcheck": check.Name},
+				Labels:    map[string]string{checkLabel: check.Name, runUUIDLabel: "run-2"},
 			},
 			Status: corev1.PodStatus{Phase: corev1.PodFailed},
 		},
@@ -271,8 +273,14 @@ func TestReaperRetainsFailedPodsWithinRetention(t *testing.T) {
 	require.NoError(t, kh.reapOnce())
 
 	var remaining corev1.PodList
-	require.NoError(t, cl.List(context.Background(), &remaining, client.InNamespace("default"), client.MatchingLabels(map[string]string{"khcheck": check.Name})))
-	require.Len(t, remaining.Items, 2)
+	require.NoError(t, cl.List(context.Background(), &remaining, client.InNamespace("default"), client.HasLabels{runUUIDLabel}))
+	var ours []corev1.Pod
+	for i := range remaining.Items {
+		if remaining.Items[i].Labels[checkLabel] == check.Name {
+			ours = append(ours, remaining.Items[i])
+		}
+	}
+	require.Len(t, ours, 2)
 }
 
 // Test that failed pods older than the retention period are removed.
@@ -300,7 +308,7 @@ func TestReaperDeletesFailedPodsPastRetention(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "failed-oldest",
 				Namespace: "default",
-				Labels:    map[string]string{"khcheck": check.Name},
+				Labels:    map[string]string{checkLabel: check.Name, runUUIDLabel: "old-1"},
 			},
 			Status: corev1.PodStatus{Phase: corev1.PodFailed},
 		},
@@ -308,7 +316,7 @@ func TestReaperDeletesFailedPodsPastRetention(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "failed-older",
 				Namespace: "default",
-				Labels:    map[string]string{"khcheck": check.Name},
+				Labels:    map[string]string{checkLabel: check.Name, runUUIDLabel: "old-2"},
 			},
 			Status: corev1.PodStatus{Phase: corev1.PodFailed},
 		},
@@ -326,6 +334,12 @@ func TestReaperDeletesFailedPodsPastRetention(t *testing.T) {
 	require.NoError(t, kh.reapOnce())
 
 	var remaining corev1.PodList
-	require.NoError(t, cl.List(context.Background(), &remaining, client.InNamespace("default"), client.MatchingLabels(map[string]string{"khcheck": check.Name})))
-	require.Len(t, remaining.Items, 0)
+	require.NoError(t, cl.List(context.Background(), &remaining, client.InNamespace("default"), client.HasLabels{runUUIDLabel}))
+	var ours []corev1.Pod
+	for i := range remaining.Items {
+		if remaining.Items[i].Labels[checkLabel] == check.Name {
+			ours = append(ours, remaining.Items[i])
+		}
+	}
+	require.Len(t, ours, 0)
 }

--- a/pkg/api/kuberhealthycheck_types.go
+++ b/pkg/api/kuberhealthycheck_types.go
@@ -17,10 +17,13 @@ limitations under the License.
 package api
 
 import (
+	"context"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -50,8 +53,6 @@ type KuberhealthyCheckStatus struct {
 	LastRunDuration time.Duration `json:"runDuration,omitempty"`
 	// Namespace is the Kubernetes namespace this pod ran in.
 	Namespace string `json:"namespace,omitempty"`
-	// PodName is the name of the Pod that was most recently created to run this check
-	PodName string `json:"podName,omitempty"`
 	// CurrentUUID is used to ensure only the most recent checker pod reports a status for this check.
 	CurrentUUID string `json:"currentUUID,omitempty"`
 	// LastRunUnix is the last time that this check was scheduled to run.
@@ -85,4 +86,53 @@ type KuberhealthyCheckList struct {
 
 func init() {
 	SchemeBuilder.Register(&KuberhealthyCheck{}, &KuberhealthyCheckList{})
+}
+
+// CurrentUUID returns the running UUID for this check.
+func (k *KuberhealthyCheck) CurrentUUID() string {
+	return k.Status.CurrentUUID
+}
+
+// SetCurrentUUID updates the running UUID on the check status.
+func (k *KuberhealthyCheck) SetCurrentUUID(u string) {
+	k.Status.CurrentUUID = u
+}
+
+// SetOK marks the check status as healthy.
+func (k *KuberhealthyCheck) SetOK() {
+	k.Status.OK = true
+}
+
+// SetNotOK marks the check status as unhealthy.
+func (k *KuberhealthyCheck) SetNotOK() {
+	k.Status.OK = false
+}
+
+// SetCheckExecutionError assigns execution errors on the check status.
+func (k *KuberhealthyCheck) SetCheckExecutionError(errs []string) {
+	k.Status.Errors = errs
+}
+
+// CreateCheck writes a new check object to the cluster.
+func CreateCheck(ctx context.Context, cl client.Client, check *KuberhealthyCheck) error {
+	return cl.Create(ctx, check)
+}
+
+// GetCheck fetches the current version of a check.
+func GetCheck(ctx context.Context, cl client.Client, nn types.NamespacedName) (*KuberhealthyCheck, error) {
+	out := &KuberhealthyCheck{}
+	if err := cl.Get(ctx, nn, out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// UpdateCheck persists status changes for a check.
+func UpdateCheck(ctx context.Context, cl client.Client, check *KuberhealthyCheck) error {
+	return cl.Status().Update(ctx, check)
+}
+
+// DeleteCheck removes a check from the cluster.
+func DeleteCheck(ctx context.Context, cl client.Client, check *KuberhealthyCheck) error {
+	return cl.Delete(ctx, check)
 }


### PR DESCRIPTION
## Summary
- remove PodName from KuberhealthyCheck status
- track checker pods via UUID labels and select pods using those labels
- ensure UUIDs are created and applied to pods on demand
- split OK status setter into dedicated setOK and setNotOK helpers
- add khcheck methods for current UUID, OK status, and execution errors
- add basic Create/Get/Update/Delete helpers for KuberhealthyCheck resources and refactor code to use them
- locate running checks via CurrentUUID accessor and update statuses with SetNotOK
- stop getCurrentUUID from generating a new UUID when one is missing

## Testing
- `go test ./...` *(hung after downloading dependencies)*
- `go test ./internal/kuberhealthy -run TestReaperTimesOutRunningPod -count=1` *(hung with no output)*

------
https://chatgpt.com/codex/tasks/task_e_68b08530fb648323b632aea889c7b48d