### PR TITLE
Ensure check pod owner references are fully enforced

### DIFF
--- a/internal/kuberhealthy/finalizer.go
+++ b/internal/kuberhealthy/finalizer.go
@@ -1,0 +1,50 @@
+package kuberhealthy
+
+import (
+	"context"
+	"fmt"
+
+	khapi "github.com/kuberhealthy/kuberhealthy/v3/pkg/api"
+)
+
+const khCheckFinalizer = "finalizer.kuberhealthy.io"
+
+// hasFinalizer returns true when the check contains the kuberhealthy finalizer.
+func (k *Kuberhealthy) hasFinalizer(check *khapi.KuberhealthyCheck) bool {
+	for _, f := range check.Finalizers {
+		if f == khCheckFinalizer {
+			return true
+		}
+	}
+	return false
+}
+
+// addFinalizer appends the kuberhealthy finalizer if it is missing.
+func (k *Kuberhealthy) addFinalizer(ctx context.Context, check *khapi.KuberhealthyCheck) error {
+	if k.hasFinalizer(check) {
+		return nil
+	}
+	check.Finalizers = append(check.Finalizers, khCheckFinalizer)
+	if err := k.CheckClient.Update(ctx, check); err != nil {
+		return fmt.Errorf("failed to add finalizer: %w", err)
+	}
+	return nil
+}
+
+// deleteFinalizer removes the kuberhealthy finalizer when present.
+func (k *Kuberhealthy) deleteFinalizer(ctx context.Context, check *khapi.KuberhealthyCheck) error {
+	if !k.hasFinalizer(check) {
+		return nil
+	}
+	var finalizers []string
+	for _, f := range check.Finalizers {
+		if f != khCheckFinalizer {
+			finalizers = append(finalizers, f)
+		}
+	}
+	check.Finalizers = finalizers
+	if err := k.CheckClient.Update(ctx, check); err != nil {
+		return fmt.Errorf("failed to remove finalizer: %w", err)
+	}
+	return nil
+}

--- a/internal/kuberhealthy/finalizer_test.go
+++ b/internal/kuberhealthy/finalizer_test.go
@@ -1,0 +1,62 @@
+package kuberhealthy
+
+import (
+	"context"
+	"testing"
+
+	khapi "github.com/kuberhealthy/kuberhealthy/v3/pkg/api"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestAddFinalizer(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	require.NoError(t, khapi.AddToScheme(scheme))
+	check := &khapi.KuberhealthyCheck{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "add-finalizer",
+			Namespace:       "default",
+			ResourceVersion: "1",
+		},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(check).Build()
+	kh := New(context.Background(), cl)
+	require.NoError(t, kh.addFinalizer(context.Background(), check))
+	fetched := &khapi.KuberhealthyCheck{}
+	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: "add-finalizer", Namespace: "default"}, fetched))
+	require.Contains(t, fetched.Finalizers, khCheckFinalizer)
+}
+
+func TestHandleUpdateRemovesFinalizer(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	require.NoError(t, khapi.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	check := &khapi.KuberhealthyCheck{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "remove-finalizer",
+			Namespace:       "default",
+			Finalizers:      []string{khCheckFinalizer},
+			ResourceVersion: "1",
+		},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(check).WithStatusSubresource(check).Build()
+	kh := New(context.Background(), cl)
+	oldU := &unstructured.Unstructured{}
+	oldU.Object, _ = runtime.DefaultUnstructuredConverter.ToUnstructured(check)
+	now := metav1.Now()
+	deleting := check.DeepCopy()
+	deleting.DeletionTimestamp = &now
+	newU := &unstructured.Unstructured{}
+	newU.Object, _ = runtime.DefaultUnstructuredConverter.ToUnstructured(deleting)
+	kh.handleUpdate(oldU, newU)
+	fetched := &khapi.KuberhealthyCheck{}
+	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: "remove-finalizer", Namespace: "default"}, fetched))
+	require.NotContains(t, fetched.Finalizers, khCheckFinalizer)
+}

--- a/internal/kuberhealthy/kuberhealthy_test.go
+++ b/internal/kuberhealthy/kuberhealthy_test.go
@@ -66,6 +66,8 @@ func TestCheckPodSpec(t *testing.T) {
 	require.Equal(t, "KuberhealthyCheck", owner.Kind)
 	require.NotNil(t, owner.Controller)
 	require.True(t, *owner.Controller)
+	require.NotNil(t, owner.BlockOwnerDeletion)
+	require.True(t, *owner.BlockOwnerDeletion)
 }
 
 func TestIsStarted(t *testing.T) {


### PR DESCRIPTION
## Summary
- confirm check pods link to their owning KuberhealthyCheck via owner references
- test now validates `BlockOwnerDeletion` flag for garbage collection

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b42073c9388323ae2e8c013052cd91