### PR TITLE
Document tests and reduce nodecheck timeout to 1s

### DIFF
--- a/cmd/kuberhealthy/config_test.go
+++ b/cmd/kuberhealthy/config_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 )
 
+// TestLoadFromEnv populates configuration fields from environment variables.
 func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("KH_LISTEN_ADDRESS", "127.0.0.1:9000")
 	t.Setenv("KH_LOG_LEVEL", "debug")
@@ -82,6 +83,7 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 }
 
+// TestLoadFromEnvInvalid returns an error when a duration environment variable is malformed.
 func TestLoadFromEnvInvalid(t *testing.T) {
 	t.Setenv("KH_MAX_JOB_AGE", "not-a-duration")
 	cfg := New()
@@ -90,6 +92,7 @@ func TestLoadFromEnvInvalid(t *testing.T) {
 	}
 }
 
+// TestReportingURLFromServiceAndNamespace constructs the reporting URL when service name and namespace are provided.
 func TestReportingURLFromServiceAndNamespace(t *testing.T) {
 	t.Setenv("POD_NAMESPACE", "ns1")
 	t.Setenv("KH_SERVICE_NAME", "svc1")

--- a/cmd/kuberhealthy/metrics_handler_test.go
+++ b/cmd/kuberhealthy/metrics_handler_test.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+// TestPrometheusMetricsEndpoint verifies the /metrics route serves Prometheus metrics.
 func TestPrometheusMetricsEndpoint(t *testing.T) {
 	t.Parallel()
 	origConfig := GlobalConfig

--- a/cmd/kuberhealthy/store_check_state_test.go
+++ b/cmd/kuberhealthy/store_check_state_test.go
@@ -35,6 +35,7 @@ func (w *conflictStatusWriter) Update(ctx context.Context, obj client.Object, op
 	return w.StatusWriter.Update(ctx, obj, opts...)
 }
 
+// TestStoreCheckStateRetriesOnConflict verifies that storeCheckState retries updates when a conflict occurs.
 func TestStoreCheckStateRetriesOnConflict(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := khapi.AddToScheme(scheme); err != nil {

--- a/cmd/kuberhealthy/webserver_test.go
+++ b/cmd/kuberhealthy/webserver_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 )
 
+// TestWebServerHandlers checks that JSON and root handlers return HTTP 200.
 func TestWebServerHandlers(t *testing.T) {
 	t.Parallel()
 	mux := newServeMux()
@@ -26,6 +27,7 @@ func TestWebServerHandlers(t *testing.T) {
 	}
 }
 
+// TestRootServesUserInterface ensures the root endpoint serves the HTML status page.
 func TestRootServesUserInterface(t *testing.T) {
 	t.Parallel()
 	mux := newServeMux()

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 )
 
+// TestAddError verifies that AddError appends entries to the state's error slice.
 func TestAddError(t *testing.T) {
 	t.Parallel()
 	s := NewState()
@@ -18,6 +19,7 @@ func TestAddError(t *testing.T) {
 	}
 }
 
+// TestWriteHTTPStatusResponse ensures the state is serialized to JSON with the expected headers and body.
 func TestWriteHTTPStatusResponse(t *testing.T) {
 	t.Parallel()
 	s := State{
@@ -44,6 +46,7 @@ func TestWriteHTTPStatusResponse(t *testing.T) {
 	}
 }
 
+// TestNewState confirms that NewState returns a healthy state with empty slices and maps initialized.
 func TestNewState(t *testing.T) {
 	t.Parallel()
 	s := NewState()

--- a/internal/health/status_test.go
+++ b/internal/health/status_test.go
@@ -2,6 +2,7 @@ package health
 
 import "testing"
 
+// TestNewReportDefaultsOK checks that a new report without errors is marked healthy.
 func TestNewReportDefaultsOK(t *testing.T) {
 	t.Parallel()
 	r := NewReport(nil)
@@ -15,6 +16,7 @@ func TestNewReportDefaultsOK(t *testing.T) {
 	}
 }
 
+// TestNewReportWithErrors confirms that providing errors results in a non-OK report.
 func TestNewReportWithErrors(t *testing.T) {
 	t.Parallel()
 	errs := []string{"err1"}

--- a/internal/kuberhealthy/kuberhealthy_test.go
+++ b/internal/kuberhealthy/kuberhealthy_test.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+// TestCheckPodSpec builds a pod from a check and asserts metadata and ownership are populated.
 func TestCheckPodSpec(t *testing.T) {
 	t.Parallel()
 	scheme := runtime.NewScheme()
@@ -68,6 +69,7 @@ func TestCheckPodSpec(t *testing.T) {
 	require.True(t, *owner.Controller)
 }
 
+// TestIsStarted verifies that IsStarted reflects the running state of Kuberhealthy.
 func TestIsStarted(t *testing.T) {
 	t.Parallel()
 	kh := &Kuberhealthy{running: true}
@@ -76,6 +78,7 @@ func TestIsStarted(t *testing.T) {
 	require.False(t, kh.IsStarted())
 }
 
+// TestSetFreshUUID ensures a new UUID is written to the check status.
 func TestSetFreshUUID(t *testing.T) {
 	t.Parallel()
 	scheme := runtime.NewScheme()
@@ -100,6 +103,7 @@ func TestSetFreshUUID(t *testing.T) {
 	require.NotEmpty(t, fetched.CurrentUUID())
 }
 
+// TestScheduleStartsCheck confirms that scheduleChecks triggers a run when a check is due.
 func TestScheduleStartsCheck(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, khapi.AddToScheme(scheme))
@@ -136,6 +140,7 @@ func TestScheduleStartsCheck(t *testing.T) {
 	require.NotZero(t, fetched.Status.LastRunUnix)
 }
 
+// TestScheduleSkipsWhenNotDue ensures scheduleChecks leaves checks untouched if their interval has not elapsed.
 func TestScheduleSkipsWhenNotDue(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, khapi.AddToScheme(scheme))
@@ -176,6 +181,7 @@ func TestScheduleSkipsWhenNotDue(t *testing.T) {
 	require.Equal(t, last, fetched.Status.LastRunUnix)
 }
 
+// TestScheduleLoopStopsOnStop verifies that Stop halts the scheduling loop.
 func TestScheduleLoopStopsOnStop(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, khapi.AddToScheme(scheme))
@@ -196,6 +202,7 @@ func TestScheduleLoopStopsOnStop(t *testing.T) {
 	require.False(t, running)
 }
 
+// TestScheduleLoopOnlyRunsOnce checks that a second schedule loop invocation exits immediately if already running.
 func TestScheduleLoopOnlyRunsOnce(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, khapi.AddToScheme(scheme))

--- a/internal/kuberhealthy/reaper_test.go
+++ b/internal/kuberhealthy/reaper_test.go
@@ -16,8 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-// Test that pods running past their timeout are terminated and the check is
-// marked as failed.
+// TestReaperTimesOutRunningPod ensures pods exceeding their timeout are deleted and the check is marked failed.
 func TestReaperTimesOutRunningPod(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, khapi.AddToScheme(scheme))
@@ -69,7 +68,7 @@ func TestReaperTimesOutRunningPod(t *testing.T) {
 	require.Empty(t, updated.CurrentUUID())
 }
 
-// Test that completed pods are removed after three run intervals have passed.
+// TestReaperRemovesCompletedPods deletes completed pods after three run intervals have passed.
 func TestReaperRemovesCompletedPods(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, khapi.AddToScheme(scheme))
@@ -111,7 +110,7 @@ func TestReaperRemovesCompletedPods(t *testing.T) {
 	require.True(t, apierrors.IsNotFound(err))
 }
 
-// Test that completed pods younger than three run intervals remain.
+// TestReaperKeepsRecentCompletedPods retains completed pods that have not exceeded the grace period.
 func TestReaperKeepsRecentCompletedPods(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, khapi.AddToScheme(scheme))
@@ -153,7 +152,7 @@ func TestReaperKeepsRecentCompletedPods(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// Test that failed pods are pruned according to retention and max count settings.
+// TestReaperPrunesFailedPods prunes failed pods based on retention days and maximum count.
 func TestReaperPrunesFailedPods(t *testing.T) {
 	t.Setenv("KH_ERROR_POD_RETENTION_DAYS", "2")
 	t.Setenv("KH_MAX_ERROR_POD_COUNT", "2")
@@ -222,7 +221,7 @@ func TestReaperPrunesFailedPods(t *testing.T) {
 	require.Len(t, ours, 2)
 }
 
-// Test that failed pods within retention limits are preserved.
+// TestReaperRetainsFailedPodsWithinRetention keeps failed pods when they fall within retention limits.
 func TestReaperRetainsFailedPodsWithinRetention(t *testing.T) {
 	t.Setenv("KH_ERROR_POD_RETENTION_DAYS", "2")
 	t.Setenv("KH_MAX_ERROR_POD_COUNT", "3")
@@ -283,7 +282,7 @@ func TestReaperRetainsFailedPodsWithinRetention(t *testing.T) {
 	require.Len(t, ours, 2)
 }
 
-// Test that failed pods older than the retention period are removed.
+// TestReaperDeletesFailedPodsPastRetention removes failed pods older than the configured retention period.
 func TestReaperDeletesFailedPodsPastRetention(t *testing.T) {
 	t.Setenv("KH_ERROR_POD_RETENTION_DAYS", "1")
 	t.Setenv("KH_MAX_ERROR_POD_COUNT", "5")

--- a/pkg/checkclient/send_report_test.go
+++ b/pkg/checkclient/send_report_test.go
@@ -11,6 +11,7 @@ import (
 	khapi "github.com/kuberhealthy/kuberhealthy/v3/pkg/api"
 )
 
+// TestReportSuccessAndFailure verifies success and failure reports send expected JSON and headers.
 func TestReportSuccessAndFailure(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -82,6 +83,7 @@ func TestReportSuccessAndFailure(t *testing.T) {
 	}
 }
 
+// TestSendReportRetry ensures ReportSuccess retries once after an initial server error.
 func TestSendReportRetry(t *testing.T) {
 	var reqs int
 

--- a/pkg/nodecheck/nodecheck_test.go
+++ b/pkg/nodecheck/nodecheck_test.go
@@ -13,10 +13,11 @@ func init() {
 	log.SetLevel(log.DebugLevel)
 }
 
+// TestWaitForKuberhealthyEndpointReady verifies the helper returns an error when the endpoint cannot be reached.
 func TestWaitForKuberhealthyEndpointReady(t *testing.T) {
 	t.Parallel()
 	khEndpoint := "http://127.0.0.1:65535/"
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, _ := context.WithTimeout(context.Background(), time.Second)
 	err := <-waitForKuberhealthyEndpointReady(ctx, khEndpoint)
 	if err == nil {
 		t.Error("Negative test failed for waitForKuberhealthyEndpointReady")


### PR DESCRIPTION
## Summary
- shorten TestWaitForKuberhealthyEndpointReady timeout from 10s to 1s to speed feedback
- add human-readable comments explaining every test

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b420919870832392f00f524587e7eb