### PR TITLE
Track check creation time in status

### DIFF
--- a/deploy/base/kuberhealthycheck.yaml
+++ b/deploy/base/kuberhealthycheck.yaml
@@ -3607,6 +3607,9 @@ spec:
                   items:
                     type: string
                   type: array
+                creationTimestamp:
+                  format: date-time
+                  type: string
                 lastRunUnix:
                   format: int64
                   type: integer

--- a/pkg/api/kuberhealthycheck_types.go
+++ b/pkg/api/kuberhealthycheck_types.go
@@ -57,6 +57,8 @@ type KuberhealthyCheckStatus struct {
 	Namespace string `json:"namespace,omitempty"`
 	// CurrentUUID is used to ensure only the most recent checker pod reports a status for this check.
 	CurrentUUID string `json:"currentUUID,omitempty"`
+	// CreationTimestamp records when the most recent checker pod was created.
+	CreationTimestamp metav1.Time `json:"creationTimestamp,omitempty"`
 	// LastRunUnix is the last time that this check was scheduled to run.
 	LastRunUnix int64 `json:"lastRunUnix,omitempty"`
 	// AdditionalMetadata is used to store additional metadata bout this check that appears in the JSON status.


### PR DESCRIPTION
## Summary
- store checker pod creation timestamp in KuberhealthyCheck status
- annotate checker pods with creation time from status
- document new field in CRD and tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b5354af00c8323a3ca94c805b9bce4