### PR TITLE
Add run now button and show running pod details

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -15,7 +15,8 @@ import (
 // last run time is unknown.
 type CheckDetail struct {
 	khapi.KuberhealthyCheckStatus
-	NextRunUnix int64 `json:"nextRunUnix,omitempty"`
+	NextRunUnix int64  `json:"nextRunUnix,omitempty"`
+	PodName     string `json:"podName,omitempty"`
 }
 
 // State represents the results of all checks being managed along with a


### PR DESCRIPTION
## Summary
- add `Run now` button next to the next run timer on the status page
- show running pod name and stream its logs while a check executes, hiding the timer and run button
- support POST `/api/run` endpoint to start a check immediately and reset its schedule

## Testing
- `go test ./...` *(hung after downloading modules; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68b53767cd748323be23e0d008494962