### PR TITLE
chore: remove creationTimestamp from khcheck

### DIFF
--- a/deploy/base/kuberhealthycheck.yaml
+++ b/deploy/base/kuberhealthycheck.yaml
@@ -3607,9 +3607,6 @@ spec:
                   items:
                     type: string
                   type: array
-                creationTimestamp:
-                  format: date-time
-                  type: string
                 lastRunUnix:
                   format: int64
                   type: integer

--- a/internal/kuberhealthy/kuberhealthy_test.go
+++ b/internal/kuberhealthy/kuberhealthy_test.go
@@ -38,9 +38,6 @@ func TestCheckPodSpec(t *testing.T) {
 				},
 			},
 		},
-		Status: khapi.KuberhealthyCheckStatus{
-			CreationTimestamp: metav1.Now(),
-		},
 	}
 
 	cl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(check).WithStatusSubresource(check).Build()
@@ -57,7 +54,6 @@ func TestCheckPodSpec(t *testing.T) {
 
 	require.Equal(t, "kuberhealthy", pod.Annotations["createdBy"])
 	require.Equal(t, check.Name, pod.Annotations["kuberhealthyCheckName"])
-	require.Equal(t, check.Status.CreationTimestamp.Time.String(), pod.Annotations["createdTime"])
 
 	require.Equal(t, check.Name, pod.Labels[checkLabel])
 	require.Equal(t, uuid, pod.Labels[runUUIDLabel])
@@ -143,7 +139,6 @@ func TestScheduleStartsCheck(t *testing.T) {
 	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: "sched-check", Namespace: "default"}, fetched))
 	require.NotEmpty(t, fetched.CurrentUUID())
 	require.NotZero(t, fetched.Status.LastRunUnix)
-	require.False(t, fetched.Status.CreationTimestamp.IsZero())
 }
 
 // TestScheduleSkipsWhenNotDue ensures scheduleChecks leaves checks untouched if their interval has not elapsed.
@@ -185,7 +180,6 @@ func TestScheduleSkipsWhenNotDue(t *testing.T) {
 	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: "skip-check", Namespace: "default"}, fetched))
 	require.Empty(t, fetched.CurrentUUID())
 	require.Equal(t, last, fetched.Status.LastRunUnix)
-	require.True(t, fetched.Status.CreationTimestamp.IsZero())
 }
 
 // TestScheduleLoopStopsOnStop verifies that Stop halts the scheduling loop.

--- a/pkg/api/kuberhealthycheck_types.go
+++ b/pkg/api/kuberhealthycheck_types.go
@@ -57,8 +57,6 @@ type KuberhealthyCheckStatus struct {
 	Namespace string `json:"namespace,omitempty"`
 	// CurrentUUID is used to ensure only the most recent checker pod reports a status for this check.
 	CurrentUUID string `json:"currentUUID,omitempty"`
-	// CreationTimestamp records when the most recent checker pod was created.
-	CreationTimestamp metav1.Time `json:"creationTimestamp,omitempty"`
 	// LastRunUnix is the last time that this check was scheduled to run.
 	LastRunUnix int64 `json:"lastRunUnix,omitempty"`
 	// AdditionalMetadata is used to store additional metadata bout this check that appears in the JSON status.

--- a/pkg/api/kuberhealthycheck_types_test.go
+++ b/pkg/api/kuberhealthycheck_types_test.go
@@ -1,0 +1,44 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestSpecDoesNotExposeCreationTimestamp ensures creationTimestamp is not serialized in pod metadata.
+func TestSpecDoesNotExposeCreationTimestamp(t *testing.T) {
+	t.Parallel()
+
+	check := &KuberhealthyCheck{
+		Spec: KuberhealthyCheckSpec{
+			PodSpec: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"foo": "bar"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "test",
+						Image: "busybox",
+					}},
+				},
+			},
+		},
+	}
+
+	raw, err := json.Marshal(check)
+	require.NoError(t, err)
+
+	var data map[string]any
+	require.NoError(t, json.Unmarshal(raw, &data))
+
+	spec := data["spec"].(map[string]any)
+	podSpec := spec["podSpec"].(map[string]any)
+	metadata := podSpec["metadata"].(map[string]any)
+	if v, found := metadata["creationTimestamp"]; found {
+		require.Nil(t, v, "creationTimestamp must be nil in spec.podSpec.metadata")
+	}
+}


### PR DESCRIPTION
## Summary
- drop creationTimestamp from KuberhealthyCheck status and CRD
- clean up controller logic and tests to avoid using creationTimestamp

## Testing
- `go test ./pkg/api -run TestSpecDoesNotExposeCreationTimestamp -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b547f05df48323ace651c89f95587a