### PR TITLE
Set default checker pod run timeout to 30s

### DIFF
--- a/cmd/kuberhealthy/README.md
+++ b/cmd/kuberhealthy/README.md
@@ -26,6 +26,6 @@ POD_NAMESPACE="kuberhealthy" # namespace Kuberhealthy runs in
 KH_SERVICE_NAME="kuberhealthy" # service name used for reports
 KH_DEFAULT_RUN_INTERVAL="10m" # default check run interval
 KH_TERMINATION_GRACE_PERIOD="5m" # shutdown grace period
-KH_DEFAULT_CHECK_TIMEOUT="5m" # default check timeout
+KH_DEFAULT_CHECK_TIMEOUT="30s" # default check timeout
 KH_DEFAULT_NAMESPACE="kuberhealthy" # fallback namespace
 ```

--- a/cmd/kuberhealthy/config.go
+++ b/cmd/kuberhealthy/config.go
@@ -49,7 +49,7 @@ func New() *Config {
 		checkReportURL:                fmt.Sprintf("%s.%s.svc.cluster.local", svc, ns),
 		DefaultRunInterval:            time.Minute * 10,
 		TerminationGracePeriodSeconds: time.Minute * 5,
-		DefaultCheckTimeout:           time.Minute * 5,
+		DefaultCheckTimeout:           30 * time.Second,
 		Namespace:                     ns,
 		ServiceName:                   svc,
 		MaxErrorPodCount:              5,

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -56,7 +56,7 @@ spec:
         - name: KH_TERMINATION_GRACE_PERIOD
           value: "5m"
         - name: KH_DEFAULT_CHECK_TIMEOUT
-          value: "5m"
+          value: "30s"
         - name: KH_DEFAULT_NAMESPACE
           value: "kuberhealthy"
         ports:

--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -21,5 +21,5 @@ Kuberhealthy is configured via environment variables and does not accept command
 | `KH_DEFAULT_RUN_INTERVAL` | Default check run interval | `10m` |
 | `KH_CHECK_REPORT_HOSTNAME` | Override hostname used for check reports | constructed |
 | `KH_TERMINATION_GRACE_PERIOD` | Shutdown grace period | `5m` |
-| `KH_DEFAULT_CHECK_TIMEOUT` | Default timeout for checks | `5m` |
+| `KH_DEFAULT_CHECK_TIMEOUT` | Default timeout for checks | `30s` |
 | `KH_DEFAULT_NAMESPACE` | Fallback namespace if detection fails | `kuberhealthy` |

--- a/internal/kuberhealthy/reaper.go
+++ b/internal/kuberhealthy/reaper.go
@@ -18,7 +18,7 @@ import (
 
 // defaultRunTimeout is the amount of time a pod is allowed to run before the
 // reaper considers it timed out.
-const defaultRunTimeout = time.Minute * 5
+const defaultRunTimeout = 30 * time.Second
 
 // defaultFailedPodRetentionDays is the number of days to retain failed pods
 // before they are reaped.


### PR DESCRIPTION
## Summary
- default khcheck pod run timeout is now 30s when unset
- document and template updates for new timeout value

## Testing
- `go test ./...` *(fails: command hung without output)*

------
https://chatgpt.com/codex/tasks/task_e_68b66a8c71748323b3f6f253f1f12703