### PR TITLE
Remove preserve unknown fields from check spec

### DIFF
--- a/deploy/base/kuberhealthycheck.yaml
+++ b/deploy/base/kuberhealthycheck.yaml
@@ -3596,7 +3596,6 @@ spec:
                 singleRunOnly:
                   type: boolean
               type: object
-              x-kubernetes-preserve-unknown-fields: true
             status:
               properties:
                 additionalMetadata:

--- a/deploy/base/kuberhealthycheck.yaml
+++ b/deploy/base/kuberhealthycheck.yaml
@@ -3593,8 +3593,12 @@ spec:
                         - containers
                       type: object
                   type: object
+                runInterval:
+                  type: string
                 singleRunOnly:
                   type: boolean
+                timeout:
+                  type: string
               type: object
             status:
               properties:

--- a/pkg/api/kuberhealthycheck_types.go
+++ b/pkg/api/kuberhealthycheck_types.go
@@ -29,7 +29,6 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// +kubebuilder:validation:XPreserveUnknownFields
 // KuberhealthyCheckSpec defines the desired state of KuberhealthyCheck
 type KuberhealthyCheckSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster

--- a/pkg/api/kuberhealthycheck_types.go
+++ b/pkg/api/kuberhealthycheck_types.go
@@ -35,8 +35,12 @@ type KuberhealthyCheckSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// SingleRun indicates that this KuberhealthyCheck will run only once.
-	SingleRun bool                   `json:"singleRunOnly,omitempty"`
-	PodSpec   corev1.PodTemplateSpec `json:"podSpec,omitempty"`
+	SingleRun bool `json:"singleRunOnly,omitempty"`
+	// RunInterval specifies how often Kuberhealthy schedules the check.
+	RunInterval *metav1.Duration `json:"runInterval,omitempty"`
+	// Timeout defines how long Kuberhealthy waits for the check to finish.
+	Timeout *metav1.Duration       `json:"timeout,omitempty"`
+	PodSpec corev1.PodTemplateSpec `json:"podSpec,omitempty"`
 	// PodSpec   v1.PodSpec              `json:"podSpec"` // We can not use a full PodSpec struct because it throws error about too much yaml in the CRD definition
 }
 


### PR DESCRIPTION
## Summary
- stop preserving unknown fields on KuberhealthyCheck spec
- drop x-kubernetes-preserve-unknown-fields from CRD

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b66945d08c832383ee31d0fdf7610a