### PR TITLE
Add curl-based example check to deploy manifests

### DIFF
--- a/deploy/base/khcheck-example.yaml
+++ b/deploy/base/khcheck-example.yaml
@@ -1,0 +1,25 @@
+apiVersion: kuberhealthy.github.io/v2
+kind: KuberhealthyCheck
+metadata:
+  name: example-check
+  namespace: kuberhealthy
+spec:
+  singleRunOnly: false
+  runInterval: 15s
+  timeout: 30s
+  podSpec:
+    spec:
+      containers:
+      - name: main
+        image: curlimages/curl:8.5.0
+        command:
+        - sh
+        - -c
+        - |
+          set -x
+          echo "Reporting to $KH_REPORTING_URL with KH_RUN_UUID=$KH_RUN_UUID"
+          curl -v --fail-with-body \
+            -H "Content-Type: application/json" \
+            -H "kh-run-uuid: $KH_RUN_UUID" \
+            -d '{"OK":true,"Errors":[]}' "$KH_REPORTING_URL"
+      restartPolicy: Never

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - kuberhealthycheck.yaml
   - clusterrole.yaml
   - serviceaccount.yaml
+  - khcheck-example.yaml


### PR DESCRIPTION
## Summary
- add example KuberhealthyCheck using curl to report success
- include example check in kustomization resources

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b66a4a693c8323a567616453d93811