### PR TITLE
Move push-to-node script into tests directory

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -24,4 +24,4 @@ kustomize: # Apply Kubernetes specs from deploy/ directory
 	kustomize build deploy/ | kubectl apply -f -
 
 deploy-k8s1: # Build, ship to k8s1 via scp, import into containerd, apply manifests, restart, list pods
-	bash ./hack/push-to-node.sh
+	bash ./tests/push-to-node.sh

--- a/tests/push-to-node.sh
+++ b/tests/push-to-node.sh
@@ -59,8 +59,8 @@ if [ "$RSYNC_OK" -ne 1 ]; then
 fi
 
 bold "Preparing remote root build script"
-REMOTE_SCRIPT="$REMOTE_BUILD_DIR/hack/build_as_root.sh"
-ssh "$REMOTE" "mkdir -p '$REMOTE_BUILD_DIR/hack'"
+REMOTE_SCRIPT="$REMOTE_BUILD_DIR/tests/build_as_root.sh"
+ssh "$REMOTE" "mkdir -p '$REMOTE_BUILD_DIR/tests'"
 ssh "$REMOTE" 'cat > '"$REMOTE_SCRIPT"' <<\'REMOTE_SCRIPT_EOF'
 #!/usr/bin/env bash
 set -euo pipefail


### PR DESCRIPTION
## Summary
- move push-to-node script into tests directory
- update remote build path and Justfile reference

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b6705090bc8323adfb0988c8092353