### PR TITLE
docs: add package readmes

### DIFF
--- a/internal/envs/README.md
+++ b/internal/envs/README.md
@@ -1,0 +1,5 @@
+# envs
+
+This package centralizes the names of environment variables used by Kuberhealthy check pods. Constants such as `KH_REPORTING_URL`, `KH_RUN_UUID`, and `KH_CHECK_RUN_DEADLINE` are defined here for reuse across packages.
+
+Its scope is limited to providing canonical variable names so that other packages can reference them without duplicating string literals or parsing logic.

--- a/internal/health/README.md
+++ b/internal/health/README.md
@@ -1,0 +1,5 @@
+# health
+
+The health package models Kuberhealthy's overall status and individual check results. It defines structures such as `State` and `CheckDetail`, helpers for appending errors, and utilities for writing JSON responses. It also includes the lightweight `Report` type used by external checks to communicate their outcomes.
+
+Its responsibilities are limited to representing health data and formatting it for consumption. Execution of checks and persistence of results are handled by other packages.

--- a/internal/khcheck/README.md
+++ b/internal/khcheck/README.md
@@ -1,0 +1,5 @@
+# khcheck
+
+khcheck defines the internal representation of a Kuberhealthy check. The `KHCheck` struct tracks scheduling parameters, runtime metadata, and cancellation controls for an individual check pod.
+
+This package is limited to the data structure and related synchronization primitives. Logic that schedules or executes checks resides in the `kuberhealthy` controller package.

--- a/internal/kuberhealthy/README.md
+++ b/internal/kuberhealthy/README.md
@@ -1,0 +1,5 @@
+# kuberhealthy
+
+This package contains the core controller that orchestrates Kuberhealthy checks. It schedules check executions, watches `KuberhealthyCheck` resources, reaps stale pods, finalizes completed runs, and records Kubernetes events.
+
+The package is responsible for coordinating check lifecycles and overall controller operation. Lower-level helpers and data definitions live in other internal and pkg packages.

--- a/internal/metrics/README.md
+++ b/internal/metrics/README.md
@@ -1,0 +1,5 @@
+# metrics
+
+The metrics package exports Kuberhealthy status information in Prometheus format. It assembles metric lines for overall health, individual checks, run durations, and failure counts, and provides helpers for writing metric responses.
+
+Its focus is on generating metrics from `health.State` data. Collection of that state and HTTP serving are delegated to other parts of the system.

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -1,0 +1,5 @@
+# api
+
+This package defines the Kubernetes CustomResource definitions used by Kuberhealthy. It exposes the `KuberhealthyCheck` type, its spec and status, and registration helpers for adding these resources to a controller-runtime scheme.
+
+The scope of this package is limited to type definitions and related helpers. Logic for running checks or interacting with the Kubernetes API is delegated to other packages.

--- a/pkg/kubeclient/README.md
+++ b/pkg/kubeclient/README.md
@@ -1,0 +1,5 @@
+# kubeclient
+
+The kubeclient package creates controller-runtime clients that understand Kuberhealthy's custom resources. It offers `NewClient` to build a `client.Client` with Kuberhealthy CRDs registered and a higher level `KHClient` wrapper with CRUD helpers for `KuberhealthyCheck` objects.
+
+This package is responsible only for constructing and wrapping Kubernetes clients. Scheduling, execution, and business logic for checks are handled elsewhere.

--- a/pkg/logruslogr/README.md
+++ b/pkg/logruslogr/README.md
@@ -1,0 +1,5 @@
+# logruslogr
+
+logruslogr provides an adapter between logrus and the `logr` logging interface. It allows components that expect a `logr.Logger` to emit structured logs through a configured logrus `Logger`.
+
+The package focuses solely on translating log calls and managing key/value pairs. Configuration and lifecycle of the underlying logrus logger remain the caller's responsibility.


### PR DESCRIPTION
## Summary
- document api, kubeclient, and logruslogr packages with new README files
- add internal package READMEs for envs, health, khcheck, kuberhealthy, and metrics

## Testing
- `go test ./...` *(failed: command hung and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b6706ea94483238af388ea7a2dc6b6