### PR TITLE
docs: add argocd deployment option

### DIFF
--- a/deploy/argocd/argocdApplication.yaml
+++ b/deploy/argocd/argocdApplication.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kuberhealthy
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/kuberhealthy/kuberhealthy.git
+    path: deploy
+    targetRevision: master
+    directory:
+      recurse: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kuberhealthy
+  syncPolicy:
+    automated: {}
+    syncOptions:
+      - CreateNamespace=true

--- a/deploy/argocd/argocdApplication.yaml
+++ b/deploy/argocd/argocdApplication.yaml
@@ -9,8 +9,6 @@ spec:
     repoURL: https://github.com/kuberhealthy/kuberhealthy.git
     path: deploy
     targetRevision: master
-    directory:
-      recurse: true
   destination:
     server: https://kubernetes.default.svc
     namespace: kuberhealthy

--- a/deploy/argocd/kustomization.yaml
+++ b/deploy/argocd/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - argocdApplication.yaml

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ Welcome to the Kuberhealthy documentation directory. These guides cover installi
 
 ## Table of Contents
 
-- [Deploying Kuberhealthy](deployingKuberhealthy.md): Install with Kustomize and expose the `/status` page with load balancers or an ingress.
+- [Deploying Kuberhealthy](deployingKuberhealthy.md): Install with Kustomize or ArgoCD and expose the `/status` page with load balancers or an ingress.
 - [Viewing Kuberhealthy Check Status](checkStatus.md): Reach the `/status` endpoint and inspect `khcheck` status fields.
 - [Creating Your Own `khcheck`](CHECK_CREATION.md): Build custom checks and craft `KuberhealthyCheck` resources.
 - [khcheck Registry](CHECKS_REGISTRY.md): Discover ready-made checks contributed by the community.

--- a/docs/deployingKuberhealthy.md
+++ b/docs/deployingKuberhealthy.md
@@ -12,6 +12,17 @@ kubectl apply -k deploy/base
 
 The base deployment exposes a Service named `kuberhealthy` on port `80` inside the cluster.
 
+## Deploy with ArgoCD
+
+Create an ArgoCD Application to manage Kuberhealthy:
+
+```sh
+kubectl apply -k deploy/argocd
+```
+
+This registers Kuberhealthy with ArgoCD and lets the controller reconcile its manifests.
+
+
 ## Exposing the Status Page
 
 Kuberhealthy serves a JSON status page at `/status`. The following sections show how to expose that page with a cloud provider load balancer or an ingress.


### PR DESCRIPTION
## Summary
- document installing Kuberhealthy as an ArgoCD application
- provide optional ArgoCD Application spec via kustomize overlay

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b6770f966c8323bca0d284e60eebef