### PR TITLE
chore: remove kubebuilder comments

### DIFF
--- a/deploy/base/kuberhealthycheck.yaml
+++ b/deploy/base/kuberhealthycheck.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
   name: kuberhealthychecks.kuberhealthy.github.io
 spec:
   group: kuberhealthy.github.io

--- a/pkg/api/groupversion_info.go
+++ b/pkg/api/groupversion_info.go
@@ -15,8 +15,6 @@ limitations under the License.
 */
 
 // Package api contains API Schema definitions for the kuberhealthy.github.io v2 API group
-// +kubebuilder:object:generate=true
-// +groupName=kuberhealthy.github.io
 package api
 
 import (

--- a/pkg/api/kuberhealthycheck_types.go
+++ b/pkg/api/kuberhealthycheck_types.go
@@ -26,9 +26,6 @@ import (
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 // KuberhealthyCheckSpec defines the desired state of KuberhealthyCheck
 type KuberhealthyCheckSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
@@ -66,10 +63,6 @@ type KuberhealthyCheckStatus struct {
 	AdditionalMetadata string `json:"additionalMetadata,omitempty"`
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Namespaced,shortName=khc;khcheck;kuberhealthycheck
-
 // KuberhealthyCheck is the Schema for the kuberhealthychecks API
 type KuberhealthyCheck struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -79,8 +72,6 @@ type KuberhealthyCheck struct {
 	// +optional
 	Status KuberhealthyCheckStatus `json:"status,omitempty"`
 }
-
-// +kubebuilder:object:root=true
 
 // KuberhealthyCheckList contains a list of KuberhealthyCheck
 type KuberhealthyCheckList struct {


### PR DESCRIPTION
## Summary
- remove leftover kubebuilder directives from API code
- drop controller-gen annotation from kuberhealthycheck CRD

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b6778cd8188323bcc55a0f5d0988c6