### PR TITLE
ci: build images for main and release tags

### DIFF
--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -3,7 +3,8 @@ name: Build and Push Image
 on:
   push:
     branches:
-      - master
+      - main
+      - v3
     paths:
       - 'cmd/**'
       - 'internal/**'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,24 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update installation references
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          sed -i -E "s|(github.com/kuberhealthy/kuberhealthy/deploy)(@[^ \n]+)?|\1@${TAG}|g" README.md
+          sed -i -E "s|(image: docker.io/kuberhealthy/kuberhealthy:).*|\1${TAG}|" deploy/base/deployment.yaml
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git diff --quiet || (git commit -am "docs: update install tag to ${TAG}" && git push origin HEAD:main)
 
       - name: Install QEMU
         run: sudo apt-get update && sudo apt-get install -y qemu-user-static

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Welcome to the Kuberhealthy documentation directory. These guides cover installi
 - [khcheck Registry](CHECKS_REGISTRY.md): Discover ready-made checks contributed by the community.
 - [Flags](FLAGS.md): Reference of command-line flags supported by Kuberhealthy.
 - [Troubleshooting](TROUBLESHOOTING.md): Solutions to common issues.
+- [Build and Release Process](buildAndRelease.md): Automated image builds and cutting new releases.
 - [Contributing](CONTRIBUTING.md): Guidelines for contributing to the project.
 - [Code of Conduct](CODE_OF_CONDUCT.md): Expected community behavior.
 - [Contributors](CONTRIBUTORS.md): Individuals who have contributed to Kuberhealthy.

--- a/docs/buildAndRelease.md
+++ b/docs/buildAndRelease.md
@@ -1,0 +1,18 @@
+# Build and Release Process
+
+This project publishes multi-architecture container images for AMD64 and ARM64.
+
+## Automatic Image Builds
+
+Changes merged to the `main` or `v3` branches that touch the `cmd`, `internal`, or `pkg` directories trigger a build of the Kuberhealthy image. The workflow builds for AMD64 and ARM64 and pushes an image tagged with `<branch>-<short-sha>` to GitHub Container Registry.
+
+## Cutting a Release
+
+Kuberhealthy releases are driven by Git tags that follow [semantic versioning](https://semver.org/).
+
+1. Ensure the desired code is merged to `main`.
+2. Create and push a tag like `v1.2.3`.
+
+Tag creation updates installation instructions and Kustomize specs to reference the new tag and publishes a multi-architecture image to Docker Hub tagged with the same version.
+
+That is all that is required to release a new version of Kuberhealthy.


### PR DESCRIPTION
## Summary
- build multi-arch images on main and v3 branch changes
- update docs and manifests with release tag and publish multi-arch images
- document automated build and release process

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b676c7a7c48323a7ac5426315a0811