### PR TITLE
Add TypeScript example client for Kuberhealthy checks

### DIFF
--- a/clients/typescript/.dockerignore
+++ b/clients/typescript/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/clients/typescript/.gitignore
+++ b/clients/typescript/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/clients/typescript/Dockerfile
+++ b/clients/typescript/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json tsconfig.json ./
+RUN npm install
+COPY src/ src/
+RUN npm run build
+CMD ["node", "dist/example.js"]

--- a/clients/typescript/Makefile
+++ b/clients/typescript/Makefile
@@ -1,0 +1,11 @@
+IMAGE ?= kuberhealthy-typescript-example:latest
+
+build:
+	npm install
+	npm run build
+
+docker-build:
+	docker build -t $(IMAGE) .
+
+docker-push:
+	docker push $(IMAGE)

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -1,0 +1,50 @@
+# TypeScript Example Check
+
+This directory contains a minimal TypeScript example for writing a [Kuberhealthy](https://github.com/kuberhealthy/kuberhealthy) external check. The script reads the `KH_REPORTING_URL` and `KH_RUN_UUID` environment variables set on checker pods and reports the result back to Kuberhealthy.
+
+## Add your logic
+
+1. Edit `src/example.ts` and replace the placeholder section with your own health check logic.
+2. Call `reportSuccess()` on success or `reportFailure()` with an array of error messages when the check fails.
+
+## Build
+
+```sh
+npm install
+npm run build
+```
+
+Run the compiled check locally by providing the required environment variables:
+
+```sh
+KH_RUN_UUID=123 KH_REPORTING_URL=http://kuberhealthy.example/externalCheckStatus node dist/example.js
+```
+
+## Docker image
+
+A simple `Dockerfile` and `Makefile` are provided.
+
+```sh
+make docker-build IMAGE=myrepo/kuberhealthy-typescript-example:latest
+make docker-push IMAGE=myrepo/kuberhealthy-typescript-example:latest
+```
+
+## Deploy with Kuberhealthy
+
+Create a `KuberhealthyCheck` that uses your image:
+
+```yaml
+apiVersion: comcast.github.io/v1
+kind: KuberhealthyCheck
+metadata:
+  name: typescript-example
+spec:
+  runInterval: 1m
+  timeout: 30s
+  podSpec:
+    containers:
+      - name: check
+        image: myrepo/kuberhealthy-typescript-example:latest
+```
+
+Apply the resource to a cluster running Kuberhealthy. The checker pod will execute the script and report its status.

--- a/clients/typescript/package-lock.json
+++ b/clients/typescript/package-lock.json
@@ -1,0 +1,48 @@
+{
+  "name": "kuberhealthy-typescript-example",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kuberhealthy-typescript-example",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^24.3.0",
+        "typescript": "^5.4.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "kuberhealthy-typescript-example",
+  "version": "1.0.0",
+  "license": "MIT",
+  "main": "dist/example.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/example.js"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -1,0 +1,44 @@
+// client.ts provides helpers for reporting status back to Kuberhealthy.
+
+interface Status {
+  ok: boolean;
+  errors: string[];
+}
+
+// getEnv retrieves a required environment variable or throws an error.
+function getEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Environment variable ${name} is required`);
+  }
+  return value;
+}
+
+// report sends the given status to the Kuberhealthy reporting URL.
+async function report(status: Status): Promise<void> {
+  const url = getEnv('KH_REPORTING_URL');
+  const uuid = getEnv('KH_RUN_UUID');
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'kh-run-uuid': uuid,
+    },
+    body: JSON.stringify(status),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to report status: ${res.status} ${res.statusText}`);
+  }
+}
+
+// reportSuccess reports a successful check run.
+export async function reportSuccess(): Promise<void> {
+  await report({ ok: true, errors: [] });
+}
+
+// reportFailure reports a failed check run with error messages.
+export async function reportFailure(errors: string[]): Promise<void> {
+  await report({ ok: false, errors });
+}

--- a/clients/typescript/src/example.ts
+++ b/clients/typescript/src/example.ts
@@ -1,0 +1,20 @@
+// example.ts is a trivial checker that always reports success.
+import { reportFailure, reportSuccess } from './client';
+
+async function main(): Promise<void> {
+  try {
+    // TODO: Add your own health check logic here.
+    await reportSuccess();
+    console.log('Reported success to Kuberhealthy');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    try {
+      await reportFailure([message]);
+    } catch (reportErr) {
+      console.error('Failed to report failure:', reportErr);
+    }
+    process.exit(1);
+  }
+}
+
+main();

--- a/clients/typescript/tsconfig.json
+++ b/clients/typescript/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add an example TypeScript client that reports success or failure to Kuberhealthy using env vars
- include Dockerfile, Makefile, and docs on building and deploying a check

## Testing
- `npm run build`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b6807af3408323952c72e7d7ade0ea