### PR TITLE
Add JavaScript example client for Kuberhealthy checks

### DIFF
--- a/clients/javascript/Dockerfile
+++ b/clients/javascript/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --production
+COPY check.js ./
+CMD ["node", "check.js"]

--- a/clients/javascript/Makefile
+++ b/clients/javascript/Makefile
@@ -1,0 +1,7 @@
+IMAGE ?= kuberhealthy-example-js:latest
+
+build:
+	docker build -t $(IMAGE) .
+
+push:
+	docker push $(IMAGE)

--- a/clients/javascript/README.md
+++ b/clients/javascript/README.md
@@ -1,0 +1,33 @@
+# JavaScript Kuberhealthy Client
+
+This directory contains an example external check for [Kuberhealthy](https://github.com/kuberhealthy/kuberhealthy) written in JavaScript. The script demonstrates how to report a successful run or a failure back to Kuberhealthy using environment variables provided to every checker pod.
+
+## Usage
+
+1. **Add your logic**: edit `check.js` and replace the placeholder section in `main` with your own check logic. Call `report(true, [])` when the check succeeds or `report(false, ["message"])` on failure.
+2. **Build the image**: run `make build IMAGE=my-registry/my-check:tag` to build a container image containing your check.
+3. **Push the image**: `make push IMAGE=my-registry/my-check:tag`.
+4. **Create a KuberhealthyCheck**: write a khcheck resource that references your image and apply it to clusters where Kuberhealthy runs.
+
+The check relies on two environment variables set automatically by Kuberhealthy:
+
+- `KH_REPORTING_URL` – the endpoint where status reports are posted.
+- `KH_RUN_UUID` – the UUID for this check run. It must be sent back in the `kh-run-uuid` header.
+
+## Example khcheck
+
+```yaml
+apiVersion: comcast.github.io/v1
+kind: KuberhealthyCheck
+metadata:
+  name: example-js-check
+  namespace: kuberhealthy
+spec:
+  runInterval: 1m
+  podSpec:
+    containers:
+      - name: check
+        image: my-registry/my-check:tag
+```
+
+Apply the file with `kubectl apply -f <file>`.

--- a/clients/javascript/README.md
+++ b/clients/javascript/README.md
@@ -17,7 +17,7 @@ The check relies on two environment variables set automatically by Kuberhealthy:
 ## Example khcheck
 
 ```yaml
-apiVersion: comcast.github.io/v1
+apiVersion: kuberhealthy.github.io/v2
 kind: KuberhealthyCheck
 metadata:
   name: example-js-check

--- a/clients/javascript/check.js
+++ b/clients/javascript/check.js
@@ -1,0 +1,46 @@
+const reportingURL = process.env.KH_REPORTING_URL;
+const runUUID = process.env.KH_RUN_UUID;
+
+if (!reportingURL || !runUUID) {
+  console.error('KH_REPORTING_URL and KH_RUN_UUID must be set');
+  process.exit(1);
+}
+
+// report sends a result to Kuberhealthy
+async function report(ok, errors) {
+  const res = await fetch(reportingURL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'kh-run-uuid': runUUID,
+    },
+    body: JSON.stringify({ ok, errors }),
+  });
+
+  if (res.ok) {
+    return;
+  }
+
+  const text = await res.text();
+  throw new Error(`Kuberhealthy responded with ${res.status}: ${text}`);
+}
+
+async function main() {
+  try {
+    // Add your check logic here.
+    await report(true, []);
+    console.log('Reported success to Kuberhealthy');
+  } catch (err) {
+    console.error('Check logic failed:', err);
+    try {
+      await report(false, [err.message]);
+    } catch (e) {
+      console.error('Failed to report failure:', e);
+    }
+    process.exit(1);
+  }
+}
+
+main();
+
+module.exports = { report };

--- a/clients/javascript/package.json
+++ b/clients/javascript/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "kuberhealthy-javascript-client",
+  "version": "0.1.0",
+  "description": "Example Kuberhealthy external check written in JavaScript",
+  "main": "check.js",
+  "scripts": {
+    "start": "node check.js"
+  },
+  "dependencies": {}
+}


### PR DESCRIPTION
## Summary
- add sample JavaScript check that reports results to Kuberhealthy
- include Dockerfile and Makefile for building and pushing an image
- document how to extend and deploy the example as a khcheck

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b6806c77348323ba2b734d1ef60d36