### PR TITLE
Add Ruby example client for external checks

### DIFF
--- a/clients/ruby/Dockerfile
+++ b/clients/ruby/Dockerfile
@@ -1,0 +1,4 @@
+FROM ruby:3.2-alpine
+WORKDIR /app
+COPY exampleCheck.rb /app/exampleCheck.rb
+CMD ["ruby", "/app/exampleCheck.rb"]

--- a/clients/ruby/Makefile
+++ b/clients/ruby/Makefile
@@ -1,0 +1,10 @@
+IMAGE ?= ruby-kh-check:latest
+
+build:
+	docker build -t \$(IMAGE) .
+
+push:
+	docker push \$(IMAGE)
+
+check:
+	ruby -c exampleCheck.rb

--- a/clients/ruby/README.md
+++ b/clients/ruby/README.md
@@ -1,0 +1,39 @@
+# Ruby Client Example
+
+This directory contains a minimal Ruby client for creating Kuberhealthy external checks.
+The script reads the `KH_REPORTING_URL` and `KH_RUN_UUID` environment variables that
+Kuberhealthy sets on checker pods and uses them to report status back to the
+Kuberhealthy service.
+
+## Using this example
+
+1. Add your own check logic to `exampleCheck.rb`.
+2. Build the container image:
+   ```sh
+   make build IMAGE=your-registry/ruby-kh-check:latest
+   ```
+3. Push the image to your registry:
+   ```sh
+   make push IMAGE=your-registry/ruby-kh-check:latest
+   ```
+4. Create a `KuberhealthyCheck` manifest that uses your image and apply it to the
+   cluster where Kuberhealthy runs:
+   ```yaml
+   apiVersion: comcast.github.io/v1
+   kind: KuberhealthyCheck
+   metadata:
+     name: ruby-example-check
+     namespace: kuberhealthy
+   spec:
+     runInterval: 1m
+     timeout: 30s
+     podSpec:
+       containers:
+       - name: ruby-example
+         image: your-registry/ruby-kh-check:latest
+         imagePullPolicy: IfNotPresent
+   ```
+
+When the check pod starts, Kuberhealthy injects `KH_RUN_UUID` and `KH_REPORTING_URL` into
+its environment. The example script reports success by default and reports failure with a
+message if an exception is raised.

--- a/clients/ruby/README.md
+++ b/clients/ruby/README.md
@@ -19,7 +19,7 @@ Kuberhealthy service.
 4. Create a `KuberhealthyCheck` manifest that uses your image and apply it to the
    cluster where Kuberhealthy runs:
    ```yaml
-   apiVersion: comcast.github.io/v1
+   apiVersion: kuberhealthy.github.io/v2
    kind: KuberhealthyCheck
    metadata:
      name: ruby-example-check

--- a/clients/ruby/exampleCheck.rb
+++ b/clients/ruby/exampleCheck.rb
@@ -25,7 +25,9 @@ def post_status(ok:, errors: [])
   req['Content-Type'] = 'application/json'
   req['kh-run-uuid'] = run_uuid
   req.body = JSON.generate({ ok: ok, errors: errors })
-  Net::HTTP.start(uri.hostname, uri.port) { |http| http.request(req) }
+  Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+    http.request(req)
+  end
 end
 
 # report_success tells Kuberhealthy the check passed.

--- a/clients/ruby/exampleCheck.rb
+++ b/clients/ruby/exampleCheck.rb
@@ -1,0 +1,46 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'net/http'
+require 'uri'
+
+# reporting_url fetches the Kuberhealthy reporting endpoint from the environment.
+def reporting_url
+  url = ENV['KH_REPORTING_URL']
+  return url if url && !url.empty?
+  raise 'KH_REPORTING_URL not set'
+end
+
+# run_uuid fetches the unique run identifier from the environment.
+def run_uuid
+  uuid = ENV['KH_RUN_UUID']
+  return uuid if uuid && !uuid.empty?
+  raise 'KH_RUN_UUID not set'
+end
+
+# post_status sends a status report back to Kuberhealthy.
+def post_status(ok:, errors: [])
+  uri = URI(reporting_url)
+  req = Net::HTTP::Post.new(uri)
+  req['Content-Type'] = 'application/json'
+  req['kh-run-uuid'] = run_uuid
+  req.body = JSON.generate({ ok: ok, errors: errors })
+  Net::HTTP.start(uri.hostname, uri.port) { |http| http.request(req) }
+end
+
+# report_success tells Kuberhealthy the check passed.
+def report_success
+  post_status(ok: true, errors: [])
+end
+
+# report_failure tells Kuberhealthy the check failed with messages.
+def report_failure(messages)
+  post_status(ok: false, errors: messages)
+end
+
+begin
+  # TODO: add check logic here. For now, always succeed.
+  report_success
+rescue StandardError => e
+  report_failure([e.message])
+end


### PR DESCRIPTION
## Summary
- add Ruby client example that reports success or failure using env vars
- document building, pushing, and deploying the Ruby check
- include Makefile and Dockerfile to build the example check

## Testing
- `ruby -c clients/ruby/exampleCheck.rb`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b680e9aeb88323bdf630cf99b8f8b6