### PR TITLE
Add bash client example

### DIFF
--- a/clients/bash/Dockerfile
+++ b/clients/bash/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine:3.20
+RUN apk add --no-cache bash curl
+COPY check.sh /check.sh
+ENTRYPOINT ["/check.sh"]

--- a/clients/bash/Makefile
+++ b/clients/bash/Makefile
@@ -1,0 +1,8 @@
+IMAGE ?= bash-check
+TAG ?= latest
+
+build:
+	docker build -t $(IMAGE):$(TAG) .
+
+push:
+	docker push $(IMAGE):$(TAG)

--- a/clients/bash/README.md
+++ b/clients/bash/README.md
@@ -1,0 +1,39 @@
+# Bash Client Example
+
+This directory demonstrates a minimal Kuberhealthy check written in Bash.
+
+The [`check.sh`](check.sh) script reads the Kuberhealthy run UUID and reporting URL from the `KH_RUN_UUID` and `KH_REPORTING_URL` environment variables that Kuberhealthy sets on checker pods. It then reports success or failure back to Kuberhealthy.
+
+## Using the example
+
+1. **Add your logic** – Replace the placeholder section in `check.sh` with commands that verify the condition you care about. Call `report_success` when the check passes or `report_failure "message"` when it fails.
+2. **Build the image** – Build a container that runs the script:
+
+   ```sh
+   make build IMAGE=your-registry/bash-check TAG=v1
+   ```
+
+3. **Push the image** – Push the image to a registry accessible by your cluster:
+
+   ```sh
+   make push IMAGE=your-registry/bash-check TAG=v1
+   ```
+
+4. **Create a KuberhealthyCheck** – Reference the image in a `KuberhealthyCheck` resource and apply it to your cluster:
+
+   ```yaml
+   apiVersion: comcast.github.io/v1
+   kind: KuberhealthyCheck
+   metadata:
+     name: bash-example
+     namespace: kuberhealthy
+   spec:
+     runInterval: 1m
+     podSpec:
+       containers:
+       - name: bash
+         image: your-registry/bash-check:v1
+         imagePullPolicy: IfNotPresent
+   ```
+
+When the pod runs, `check.sh` will report its result to Kuberhealthy. Set the `FAIL=true` environment variable to simulate a failure.

--- a/clients/bash/README.md
+++ b/clients/bash/README.md
@@ -22,7 +22,7 @@ The [`check.sh`](check.sh) script reads the Kuberhealthy run UUID and reporting 
 4. **Create a KuberhealthyCheck** – Reference the image in a `KuberhealthyCheck` resource and apply it to your cluster:
 
    ```yaml
-   apiVersion: comcast.github.io/v1
+   apiVersion: kuberhealthy.github.io/v2
    kind: KuberhealthyCheck
    metadata:
      name: bash-example

--- a/clients/bash/check.sh
+++ b/clients/bash/check.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Load Kuberhealthy run metadata from environment variables provided to the pod.
+UUID="${KH_RUN_UUID:-}"
+REPORT_URL="${KH_REPORTING_URL:-}"
+
+if [[ -z "$UUID" || -z "$REPORT_URL" ]]; then
+  echo "KH_RUN_UUID and KH_REPORTING_URL must be set" >&2
+  exit 1
+fi
+
+report_success() {
+  curl -sS -X POST \
+    -H "Content-Type: application/json" \
+    -H "kh-run-uuid: ${UUID}" \
+    -d '{"ok":true,"errors":[]}' \
+    "${REPORT_URL}"
+}
+
+report_failure() {
+  local msg="$1"
+  curl -sS -X POST \
+    -H "Content-Type: application/json" \
+    -H "kh-run-uuid: ${UUID}" \
+    -d '{"ok":false,"errors":["'"${msg}"'"]}' \
+    "${REPORT_URL}"
+}
+
+# Add your check logic here. For example purposes, this check reports success
+# unless the FAIL environment variable is set to "true".
+if [[ "${FAIL:-}" == "true" ]]; then
+  report_failure "FAIL was set to true"
+else
+  report_success
+fi


### PR DESCRIPTION
## Summary
- add example Bash client that posts success or failure to Kuberhealthy
- document building and deploying the check

## Testing
- `bash -n clients/bash/check.sh`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68b680ba60e88323b78a5912fc9328e5