### PR TITLE
Add Java example client

### DIFF
--- a/clients/java/Dockerfile
+++ b/clients/java/Dockerfile
@@ -1,0 +1,9 @@
+FROM openjdk:17-jdk-slim AS build
+WORKDIR /app
+COPY ExampleCheck.java .
+RUN javac ExampleCheck.java
+
+FROM openjdk:17-jre-slim
+WORKDIR /app
+COPY --from=build /app/ExampleCheck.class .
+ENTRYPOINT ["java", "ExampleCheck"]

--- a/clients/java/ExampleCheck.java
+++ b/clients/java/ExampleCheck.java
@@ -1,0 +1,55 @@
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+public class ExampleCheck {
+    public static void main(String[] args) throws Exception {
+        String url = System.getenv("KH_REPORTING_URL");
+        String uuid = System.getenv("KH_RUN_UUID");
+
+        if (url == null || url.isEmpty() || uuid == null || uuid.isEmpty()) {
+            System.err.println("KH_REPORTING_URL and KH_RUN_UUID must be set");
+            System.exit(1);
+        }
+
+        // Replace this with your own check logic. If the check passes, leave
+        // ok as true. To report a failure, set ok to false and provide an
+        // error message.
+        boolean ok = true;
+        String error = "";
+
+        // Example: report a failure with an error message
+        // ok = false;
+        // error = "something went wrong";
+
+        report(url, uuid, ok, error);
+    }
+
+    private static void report(String url, String uuid, boolean ok, String errorMessage) throws IOException {
+        String payload = "{\"ok\":true,\"errors\":[]}";
+        if (!ok) {
+            payload = "{\"ok\":false,\"errors\":[\"" + escape(errorMessage) + "\"]}";
+        }
+
+        HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
+        conn.setRequestMethod("POST");
+        conn.setRequestProperty("Content-Type", "application/json");
+        conn.setRequestProperty("kh-run-uuid", uuid);
+        conn.setDoOutput(true);
+
+        try (OutputStream os = conn.getOutputStream()) {
+            os.write(payload.getBytes(StandardCharsets.UTF_8));
+        }
+
+        int code = conn.getResponseCode();
+        if (code != 200 && code != 400) {
+            throw new IOException("unexpected response code: " + code);
+        }
+    }
+
+    private static String escape(String s) {
+        return s.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+}

--- a/clients/java/Makefile
+++ b/clients/java/Makefile
@@ -1,0 +1,9 @@
+IMAGE ?= kuberhealthy/java-example:latest
+
+.PHONY: build
+build:
+	docker build -t $(IMAGE) .
+
+.PHONY: push
+push: build
+	docker push $(IMAGE)

--- a/clients/java/README.md
+++ b/clients/java/README.md
@@ -1,0 +1,50 @@
+# Java Client Example
+
+This directory shows how to write a minimal Java check for [Kuberhealthy](https://github.com/kuberhealthy/kuberhealthy). The `ExampleCheck` program reads the `KH_REPORTING_URL` and `KH_RUN_UUID` environment variables that Kuberhealthy injects into checker pods and posts a JSON status report.
+
+## Extending the check
+
+Add your own logic inside `ExampleCheck.java` before the call to `report`. The file defaults to reporting success and includes commented-out lines that show how to report a failure:
+
+```java
+// ok = false;
+// error = "something went wrong";
+```
+
+Call `report` with `ok=true` when the check succeeds or `ok=false` with an error message when it fails.
+
+## Building and pushing
+
+Build and push the container image:
+
+```bash
+make build IMAGE=registry.example.com/java-example:latest
+make push IMAGE=registry.example.com/java-example:latest
+```
+
+## Deploying
+
+Create a `KuberhealthyCheck` that uses the pushed image:
+
+```yaml
+apiVersion: khcheck.kuberhealthy.io/v1
+kind: KuberhealthyCheck
+metadata:
+  name: java-example
+spec:
+  runInterval: 15m
+  timeout: 5m
+  podSpec:
+    containers:
+    - name: checker
+      image: registry.example.com/java-example:latest
+      imagePullPolicy: Always
+```
+
+Apply the manifest to a cluster running Kuberhealthy:
+
+```bash
+kubectl apply -f khcheck.yaml
+```
+
+The pod will receive the required `KH_REPORTING_URL` and `KH_RUN_UUID` variables and the check will report success or failure back to Kuberhealthy.


### PR DESCRIPTION
## Summary
- add Java example that reports success or failure to Kuberhealthy using environment variables
- include Dockerfile and Makefile for building and pushing the check image
- document how to extend and deploy the example check with Kuberhealthy

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b68088a03c8323a7d2a17893f67b1f