### PR TITLE
Add example Go client check

### DIFF
--- a/clients/go/Dockerfile
+++ b/clients/go/Dockerfile
@@ -1,0 +1,12 @@
+# syntax=docker/dockerfile:1
+FROM golang:1.24 AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+WORKDIR /src/clients/go
+RUN go build -o /bin/example-check .
+
+FROM gcr.io/distroless/base-debian12
+COPY --from=builder /bin/example-check /example-check
+ENTRYPOINT ["/example-check"]

--- a/clients/go/Makefile
+++ b/clients/go/Makefile
@@ -1,0 +1,13 @@
+BINARY := example-check
+IMAGE ?= example-check:latest
+
+build:
+	go build -o $(BINARY) .
+
+docker-build:
+	docker build -t $(IMAGE) -f Dockerfile ../..
+
+docker-push:
+	docker push $(IMAGE)
+
+.PHONY: build docker-build docker-push

--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -1,0 +1,44 @@
+# Example Go Client
+
+This directory contains a minimal Go program that reports its status back to [Kuberhealthy](https://github.com/kuberhealthy/kuberhealthy). The program reads the `KH_REPORTING_URL` and `KH_RUN_UUID` environment variables injected into checker pods and sends either a success or failure result using the `checkclient` package.
+
+## Customizing the Check
+
+1. Edit `main.go` and add your own logic.
+2. Call `checkclient.ReportSuccess()` when your check passes.
+3. Call `checkclient.ReportFailure([]string{"message"})` when it fails.
+
+## Building
+
+```sh
+make build
+make docker-build IMAGE=yourrepo/example-check:tag
+make docker-push IMAGE=yourrepo/example-check:tag
+```
+
+## Deploying
+
+Create a `KHCheck` that references the image you built:
+
+```yaml
+apiVersion: kuberhealthy.github.io/v2
+kind: KHCheck
+metadata:
+  name: example-check
+spec:
+  runInterval: 1m
+  timeout: 30s
+  podSpec:
+    containers:
+    - name: example
+      image: yourrepo/example-check:tag
+      env:
+      - name: FAIL
+        value: "true"
+```
+
+Apply the resource to any cluster running Kuberhealthy:
+
+```sh
+kubectl apply -f khcheck.yaml
+```

--- a/clients/go/main.go
+++ b/clients/go/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	checkclient "github.com/kuberhealthy/kuberhealthy/v3/pkg/checkclient"
+)
+
+// main demonstrates how an external check can report its status back to
+// Kuberhealthy. The checker uses environment variables provided to the pod
+// by Kuberhealthy to know where and how to report results.
+func main() {
+	reportingURL := os.Getenv("KH_REPORTING_URL")
+	runUUID := os.Getenv("KH_RUN_UUID")
+	log.Printf("reporting to %s with run UUID %s", reportingURL, runUUID)
+
+	// Set FAIL=true to demonstrate a failing result.
+	if os.Getenv("FAIL") == "true" {
+		err := checkclient.ReportFailure([]string{"example failure"})
+		if err != nil {
+			log.Fatalf("failed to report failure: %v", err)
+		}
+		return
+	}
+
+	err := checkclient.ReportSuccess()
+	if err != nil {
+		log.Fatalf("failed to report success: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add example Go client demonstrating success and failure reports using env vars
- document how to build and deploy the sample check
- update example KHCheck YAML to use apiVersion `kuberhealthy.github.io/v2`

## Testing
- `go test ./...` *(terminated after long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68b6809bf86c83238c2eb9d2db2b8d07