### PR TITLE
docs: streamline README and expand docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,14 +4,15 @@ Welcome to the Kuberhealthy documentation directory. These guides cover installi
 
 ## Table of Contents
 
-- [Deploying Kuberhealthy](deployingKuberhealthy.md): Install with Kustomize or ArgoCD and expose the `/status` page with load balancers or an ingress.
-- [Viewing Kuberhealthy Check Status](checkStatus.md): Reach the `/status` endpoint and inspect `khcheck` status fields.
-- [Creating Your Own `khcheck`](CHECK_CREATION.md): Build custom checks and craft `KuberhealthyCheck` resources.
-- [khcheck Registry](CHECKS_REGISTRY.md): Discover ready-made checks contributed by the community.
-- [Flags](FLAGS.md): Reference of command-line flags supported by Kuberhealthy.
-- [Troubleshooting](TROUBLESHOOTING.md): Solutions to common issues.
-- [Build and Release Process](buildAndRelease.md): Automated image builds and cutting new releases.
-- [Contributing](CONTRIBUTING.md): Guidelines for contributing to the project.
-- [Code of Conduct](CODE_OF_CONDUCT.md): Expected community behavior.
-- [Contributors](CONTRIBUTORS.md): Individuals who have contributed to Kuberhealthy.
-- [Adopters](ADOPTERS.md): Organizations using Kuberhealthy in production.
+- 🚀 [Deploying Kuberhealthy](deployingKuberhealthy.md): Install with Kustomize or ArgoCD and expose the `/status` page with load balancers or an ingress.
+- 📊 [Viewing Kuberhealthy Check Status](checkStatus.md): Reach the `/status` endpoint and inspect `khcheck` status fields.
+- 🧠 [How Kuberhealthy Works](howItWorks.md): Illustration of the check lifecycle and controller interaction.
+- 🛠️ [Creating Your Own `khcheck`](CHECK_CREATION.md): Build custom checks and craft `KuberhealthyCheck` resources.
+- 🗂️ [khcheck Registry](CHECKS_REGISTRY.md): Discover ready-made checks contributed by the community.
+- 🚩 [Flags](FLAGS.md): Reference of command-line flags supported by Kuberhealthy.
+- 🐞 [Troubleshooting](TROUBLESHOOTING.md): Solutions to common issues.
+- 🏗️ [Build and Release Process](buildAndRelease.md): Automated image builds and cutting new releases.
+- 🤝 [Contributing](CONTRIBUTING.md): Guidelines for contributing to the project.
+- 📜 [Code of Conduct](CODE_OF_CONDUCT.md): Expected community behavior.
+- 👥 [Contributors](CONTRIBUTORS.md): Individuals who have contributed to Kuberhealthy.
+- 🏢 [Adopters](ADOPTERS.md): Organizations using Kuberhealthy in production.

--- a/docs/checkStatus.md
+++ b/docs/checkStatus.md
@@ -6,6 +6,56 @@ Kuberhealthy exposes the state of every `khcheck` through two interfaces: the we
 
 The Kuberhealthy Service serves a read‑only JSON status page at `/status`.
 
+### Example Output
+
+```json
+{
+    "OK": true,
+    "Errors": [],
+    "CheckDetails": {
+        "kuberhealthy/daemonset": {
+            "OK": true,
+            "Errors": [],
+            "RunDuration": "22.512278967s",
+            "Namespace": "kuberhealthy",
+            "LastRun": "2019-11-14T23:24:16.7718171Z",
+            "AuthoritativePod": "kuberhealthy-67bf8c4686-mbl2j",
+            "uuid": "9abd3ec0-b82f-44f0-b8a7-fa6709f759cd"
+        },
+        "kuberhealthy/deployment": {
+            "OK": true,
+            "Errors": [],
+            "RunDuration": "29.142295647s",
+            "Namespace": "kuberhealthy",
+            "LastRun": "2019-11-14T23:26:40.7444659Z",
+            "AuthoritativePod": "kuberhealthy-67bf8c4686-mbl2j",
+            "uuid": "5f0d2765-60c9-47e8-b2c9-8bc6e61727b2"
+        },
+        "kuberhealthy/dns-status-internal": {
+            "OK": true,
+            "Errors": [],
+            "RunDuration": "2.43940936s",
+            "Namespace": "kuberhealthy",
+            "LastRun": "2019-11-14T23:34:04.8927434Z",
+            "AuthoritativePod": "kuberhealthy-67bf8c4686-mbl2j",
+            "uuid": "c85f95cb-87e2-4ff5-b513-e02b3d25973a"
+        },
+        "kuberhealthy/pod-restarts": {
+            "OK": true,
+            "Errors": [],
+            "RunDuration": "2.979083775s",
+            "Namespace": "kuberhealthy",
+            "LastRun": "2019-11-14T23:34:06.1938491Z",
+            "AuthoritativePod": "kuberhealthy-67bf8c4686-mbl2j",
+            "uuid": "a718b969-421c-47a8-a379-106d234ad9d8"
+        }
+    },
+    "CurrentMaster": "kuberhealthy-7cf79bdc86-m78qr"
+}
+```
+
+The boolean `OK` field can be used to indicate global up/down status, while the `Errors` array contains all check error descriptions. Granular per-check information, including run duration, last run time, and the Kuberhealthy pod that executed the check, is available under the `CheckDetails` object.
+
 ### Using Port Forwarding
 
 If the Service is only reachable inside the cluster, port‑forward to it:

--- a/docs/deployingKuberhealthy.md
+++ b/docs/deployingKuberhealthy.md
@@ -64,3 +64,29 @@ kubectl apply -k deploy/ingress
 ```
 
 The ingress overlay creates a simple HTTP ingress pointing to the Kuberhealthy Service.
+
+## Configuration
+
+Kuberhealthy is configured entirely with environment variables. The deployment manifest in this repository includes default values for all options. Modify the container's environment variables to tune Kuberhealthy for your cluster. See [FLAGS.md](FLAGS.md) for the full list.
+
+## Viewing Configured Checks
+
+You can list checks that are configured with:
+
+```sh
+kubectl -n kuberhealthy get khcheck
+```
+
+Check status can be accessed via the JSON status page endpoint or by inspecting the status field on the `KuberhealthyCheck` resource.
+
+## Verifying the Deployment
+
+After installation, verify that Kuberhealthy is running and serving metrics:
+
+```sh
+kubectl get pods -n kuberhealthy
+kubectl -n kuberhealthy port-forward svc/kuberhealthy 8080:80 &
+curl -f localhost:8080/metrics
+```
+
+The `kuberhealthy` pod should be in a `Running` state and the metrics endpoint should respond. If checks fail, consult the [troubleshooting guide](TROUBLESHOOTING.md).

--- a/docs/howItWorks.md
+++ b/docs/howItWorks.md
@@ -1,0 +1,16 @@
+# How Kuberhealthy Works
+
+Here is an illustration of how Kuberhealthy provisions and operates checker pods. The following process is illustrated:
+
+- An admin creates a [`KuberhealthyCheck`](CHECKS.md#khcheck-anatomy) resource that calls for a synthetic Kubernetes daemonset to be deployed and tested every 15 minutes. This will ensure that all nodes in the Kubernetes cluster can provision containers properly.
+- Kuberhealthy observes this new `KuberhealthyCheck` resource.
+- Kuberhealthy schedules a checker pod to manage the lifecycle of this check.
+- The checker pod creates a daemonset using the Kubernetes API.
+- The checker pod observes the daemonset and waits for all daemonset pods to become `Ready`.
+- The checker pod deletes the daemonset using the Kubernetes API.
+- The checker pod observes the daemonset being fully cleaned up and removed.
+- The checker pod reports a successful test result back to Kuberhealthy's API.
+- Kuberhealthy stores this check's state and makes it available to various metrics systems.
+
+<img src="../assets/kh-ds-check.gif" alt="Kuberhealthy daemonset check illustration" />
+


### PR DESCRIPTION
## Summary
- simplify README and link to docs
- add emoji-filled documentation table of contents
- document Kuberhealthy architecture and installation details
- restore header and demonstration gif in README

## Testing
- `go test ./...` *(fails: command hung; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68b68dc5601c832390ce4c1f9242ff43