### PR TITLE
docs: add client library references

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ Kuberhealthy creating and tearing down a daemonset across the cluster:
 
 For advanced configuration options, see the [deployment guide](docs/deployingKuberhealthy.md) and the [full documentation](docs/).
 
+## Client Libraries and Examples
+
+Kuberhealthy offers example applications and importable clients for a variety of languages:
+
+- [Rust](https://github.com/kuberhealthy/rust)
+- [TypeScript](https://github.com/kuberhealthy/typescript)
+- [JavaScript](https://github.com/kuberhealthy/javascript)
+- [Go](https://github.com/kuberhealthy/go)
+- [Python](https://github.com/kuberhealthy/python)
+- [Ruby](https://github.com/kuberhealthy/ruby)
+- [Java](https://github.com/kuberhealthy/java)
+- [Bash](https://github.com/kuberhealthy/bash)
+
 ## Learn More
 
 - 🧠 [How Kuberhealthy Works](docs/howItWorks.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,19 @@
 
 Welcome to the Kuberhealthy documentation directory. These guides cover installing, using, and contributing to Kuberhealthy.
 
+## Client Libraries and Examples
+
+Kuberhealthy provides example applications and importable clients for multiple languages:
+
+- [Rust](https://github.com/kuberhealthy/rust)
+- [TypeScript](https://github.com/kuberhealthy/typescript)
+- [JavaScript](https://github.com/kuberhealthy/javascript)
+- [Go](https://github.com/kuberhealthy/go)
+- [Python](https://github.com/kuberhealthy/python)
+- [Ruby](https://github.com/kuberhealthy/ruby)
+- [Java](https://github.com/kuberhealthy/java)
+- [Bash](https://github.com/kuberhealthy/bash)
+
 ## Table of Contents
 
 - 🚀 [Deploying Kuberhealthy](deployingKuberhealthy.md): Install with Kustomize or ArgoCD and expose the `/status` page with load balancers or an ingress.


### PR DESCRIPTION
## Summary
- document example client libraries available in multiple languages

## Testing
- `go test -short ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b69ace674883238ec893bb189712f0