### PR TITLE
docs: expand migration guide

### DIFF
--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -1,8 +1,58 @@
+# Migration Guide
+
+Kuberhealthy v3 moves from the Helm chart on the `master` branch to a kustomize
+application on the `main` branch and introduces a single
+`KuberhealthyCheck` resource using the `kuberhealthy.github.io/v2` API. It
+replaces the legacy `KuberhealthyCheck`, `KuberhealthyState`, and
+`KuberhealthyJob` resources.
+
+Benefits of switching:
+
+- One simplified CRD – `KHCheck` now covers periodic checks and one‑time jobs
+  via the `runOnce` flag.
+- Mutating webhook keeps existing `comcast.github.io/v1` resources working so
+  you can migrate at your own pace.
+- Kustomize install from the `main` branch enables GitOps workflows and easier
+  upgrades.
+- Existing check clients remain compatible; only the operator changes.
+- Re‑deploying the operator causes only a brief downtime for running checker
+  pods.
+
+## Step-by-step migration from Helm to kustomize
+
+1. **Prepare** – Back up any Helm values and ensure `kubectl` has kustomize
+   support. Re‑deploying the operator results in a small amount of downtime for
+   running check pods.
+2. **Uninstall the Helm chart** – Remove the old release:
+
+   ```bash
+   helm uninstall kuberhealthy -n kuberhealthy
+   ```
+
+   This deletes the deployment and old CRDs but leaves your `khcheck`
+   resources.
+3. **Install via kustomize** – Apply the manifests from the new branch:
+
+   ```bash
+   kubectl apply -k github.com/kuberhealthy/kuberhealthy/deploy?ref=main
+   ```
+
+   Wait for the `kuberhealthy` deployment to become ready.
+4. **Verify existing checks** – Thanks to the mutating webhook, `khcheck`
+   manifests that still specify `apiVersion: comcast.github.io/v1` continue to
+   run without modification. Existing check clients also continue to work.
+5. **Replace khjobs** – The legacy `khjob` resource is now a `KuberhealthyCheck`
+   with `runOnce: true`. Apply the new manifest and delete the old `khjob`.
+6. **Update branch references** – Any scripts or documentation referring to the
+   `master` branch (for example raw manifest URLs) should now point to `main`.
+
+After the migration you may delete the legacy CRDs
+`khchecks.comcast.github.io`, `kuberhealthystates.comcast.github.io`, and
+`khjobs.comcast.github.io` once no resources remain.
+
+---
+
 # KHCheck Migration Examples
-
-Kuberhealthy v3 introduces a single `KuberhealthyCheck` resource using the `kuberhealthy.github.io/v2` API. It replaces the legacy `KuberhealthyCheck`, `KuberhealthyState`, and `KuberhealthyJob` resources.
-
-Existing manifests continue to work. A mutating webhook automatically converts old resources on apply, making migration straightforward.
 
 ## khcheck and khstate
 
@@ -69,7 +119,7 @@ kind: KuberhealthyCheck
 metadata:
   name: backup
 spec:
-  runInterval: 0
+  runOnce: true
   timeout: 15m
   podSpec:
     restartPolicy: Never


### PR DESCRIPTION
## Summary
- explain benefits of the new kustomize-based install and KHCheck API
- add step-by-step migration from Helm chart to kustomize app
- document khjob replacement with KHCheck runOnce flag and other migration tips

## Testing
- `go test ./...` *(fails: command hung, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a5f7b7308323a7c6094c08395571