### PR TITLE
Fix khcheck deletion hang by removing finalizer on delete events

### DIFF
--- a/internal/kuberhealthy/finalizer_test.go
+++ b/internal/kuberhealthy/finalizer_test.go
@@ -7,6 +7,7 @@ import (
 	khapi "github.com/kuberhealthy/kuberhealthy/v3/pkg/api"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -58,5 +59,34 @@ func TestHandleUpdateRemovesFinalizer(t *testing.T) {
 	kh.handleUpdate(oldU, newU)
 	fetched := &khapi.KuberhealthyCheck{}
 	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: "remove-finalizer", Namespace: "default"}, fetched))
+	require.NotContains(t, fetched.Finalizers, khCheckFinalizer)
+}
+
+func TestHandleDeleteRemovesFinalizer(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	require.NoError(t, khapi.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	now := metav1.Now()
+	check := &khapi.KuberhealthyCheck{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "delete-finalizer",
+			Namespace:         "default",
+			Finalizers:        []string{khCheckFinalizer},
+			ResourceVersion:   "1",
+			DeletionTimestamp: &now,
+		},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(check).WithStatusSubresource(check).Build()
+	kh := New(context.Background(), cl)
+	u := &unstructured.Unstructured{}
+	u.Object, _ = runtime.DefaultUnstructuredConverter.ToUnstructured(check)
+	kh.handleDelete(u)
+	fetched := &khapi.KuberhealthyCheck{}
+	err := cl.Get(context.Background(), types.NamespacedName{Name: "delete-finalizer", Namespace: "default"}, fetched)
+	if apierrors.IsNotFound(err) {
+		return
+	}
+	require.NoError(t, err)
 	require.NotContains(t, fetched.Finalizers, khCheckFinalizer)
 }

--- a/internal/kuberhealthy/watch.go
+++ b/internal/kuberhealthy/watch.go
@@ -92,6 +92,21 @@ func (kh *Kuberhealthy) handleDelete(obj interface{}) {
 		log.Errorln("error:", err)
 		return
 	}
+	if kh.hasFinalizer(khc) {
+		if err := kh.StopCheck(khc); err != nil {
+			log.Errorln("error:", err)
+		}
+		nn := types.NamespacedName{Namespace: khc.Namespace, Name: khc.Name}
+		refreshed, err := khapi.GetCheck(kh.Context, kh.CheckClient, nn)
+		if err != nil {
+			log.Errorln("error:", err)
+			return
+		}
+		if err := kh.deleteFinalizer(kh.Context, refreshed); err != nil {
+			log.Errorln("error:", err)
+		}
+		return
+	}
 	if err := kh.StopCheck(khc); err != nil {
 		log.Errorln("error:", err)
 	}


### PR DESCRIPTION
## Summary
- remove kuberhealthy finalizer when delete watch events are received
- add regression test for finalizer cleanup on delete

## Testing
- `go test -short ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b6a95968848323861ccef6c1a9974c