### PR TITLE
Add check run countdowns and home link

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -15,8 +15,9 @@ import (
 // last run time is unknown.
 type CheckDetail struct {
 	khapi.KuberhealthyCheckStatus
-	NextRunUnix int64  `json:"nextRunUnix,omitempty"`
-	PodName     string `json:"podName,omitempty"`
+	NextRunUnix    int64  `json:"nextRunUnix,omitempty"`
+	PodName        string `json:"podName,omitempty"`
+	TimeoutSeconds int64  `json:"timeoutSeconds,omitempty"`
 }
 
 // State represents the results of all checks being managed along with a


### PR DESCRIPTION
## Summary
- show timeout countdown for running checks
- expose check timeouts in JSON
- make header logo return to main check list

## Testing
- `go test -short ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b7d248be5c83238c437a89376f4e7b