### PR TITLE
Expose fast healthz endpoint for Kubernetes probes

### DIFF
--- a/cmd/kuberhealthy/webserver_test.go
+++ b/cmd/kuberhealthy/webserver_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 // TestWebServerHandlers checks that JSON and root handlers return HTTP 200.
@@ -50,5 +52,33 @@ func TestRootServesUserInterface(t *testing.T) {
 		if !strings.Contains(string(b), "<title>Kuberhealthy Status</title>") {
 			t.Fatalf("expected status page HTML for %s", u)
 		}
+	}
+}
+
+// TestHealthzHandler ensures the /healthz endpoint reports OK.
+func TestHealthzHandler(t *testing.T) {
+	t.Parallel()
+	orig := Globals.kubeClient
+	Globals.kubeClient = fake.NewSimpleClientset()
+	t.Cleanup(func() { Globals.kubeClient = orig })
+
+	mux := newServeMux()
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("failed to GET /healthz: %v", err)
+	}
+	b, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatalf("failed to read body: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200 got %d", resp.StatusCode)
+	}
+	if string(b) != "OK" {
+		t.Fatalf("expected body OK got %q", string(b))
 	}
 }

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -66,6 +66,18 @@ spec:
         ports:
         - containerPort: 80
         - containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 10
         volumeMounts:
         - name: webhook-tls
           mountPath: /tls

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17,20 +17,17 @@ paths:
                 type: string
   /healthz:
     get:
-      summary: Get current status of all checks
-      parameters:
-        - in: query
-          name: namespace
-          schema:
-            type: string
-          description: Comma-separated namespaces to filter by
+      summary: Quick health check
       responses:
         '200':
-          description: Health status
+          description: Service is healthy
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/State'
+                type: string
+                example: OK
+        '503':
+          description: Dependencies unavailable
   /json:
     get:
       summary: Get current status of all checks


### PR DESCRIPTION
## Summary
- add lightweight `/healthz` handler that verifies Kubernetes client access
- document healthz in OpenAPI spec
- point deployment liveness and readiness probes to the new endpoint
- test that healthz responds with `OK`

## Testing
- `go test -short ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b7db0f1a608323a2a355edb23ce97a