### PR TITLE
Use domain qualified finalizer name

### DIFF
--- a/internal/kuberhealthy/finalizer.go
+++ b/internal/kuberhealthy/finalizer.go
@@ -7,7 +7,7 @@ import (
 	khapi "github.com/kuberhealthy/kuberhealthy/v3/pkg/api"
 )
 
-const khCheckFinalizer = "finalizer.kuberhealthy.io"
+const khCheckFinalizer = "kuberhealthy.io/kuberhealthycheck"
 
 // hasFinalizer returns true when the check contains the kuberhealthy finalizer.
 func (k *Kuberhealthy) hasFinalizer(check *khapi.KuberhealthyCheck) bool {


### PR DESCRIPTION
## Summary
- rename Kuberhealthy check finalizer to `kuberhealthy.io/kuberhealthycheck`

## Testing
- `go test -short ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b7e1debbd88323a57b10134b2e387a