### PR TITLE
Support local Podman-based deployment

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -23,5 +23,6 @@ run: # Run Kuberhealthy locally
 kustomize: # Apply Kubernetes specs from deploy/ directory
 	kustomize build deploy/ | kubectl apply -f -
 
-deploy-k8s1: # Build, ship to k8s1 via scp, import into containerd, apply manifests, restart, list pods
-	bash ./tests/push-to-node.sh
+deploy-k8s: # Build, load into local kind cluster, apply manifests, restart, list pods
+	bash ./tests/deployLocalKind.sh
+

--- a/tests/deployLocalKind.sh
+++ b/tests/deployLocalKind.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+[ "${DEBUG:-}" = "1" ] && set -x
+
+IMAGE="${IMAGE:-kuberhealthy:localdev}"
+CLUSTER="${CLUSTER:-kuberhealthy-dev}"
+NAMESPACE="${NAMESPACE:-kuberhealthy}"
+
+bold() {
+  printf "\033[1m%s\033[0m\n" "$*"
+}
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing dependency: $1" >&2
+    exit 1
+  fi
+}
+
+bold "Checking prerequisites"
+need podman
+need kind
+need kubectl
+if ! command -v kustomize >/dev/null 2>&1; then
+  if ! kubectl kustomize >/dev/null 2>&1; then
+    echo "kustomize not found" >&2
+    exit 1
+  fi
+fi
+
+bold "Building local image"
+podman build -f cmd/kuberhealthy/Podfile -t "$IMAGE" .
+
+bold "Loading image into kind cluster '$CLUSTER'"
+TMP_TAR="/tmp/kuberhealthy-image.tar"
+podman save "$IMAGE" -o "$TMP_TAR"
+kind load image-archive "$TMP_TAR" --name "$CLUSTER"
+rm -f "$TMP_TAR"
+
+bold "Applying Kuberhealthy manifests"
+if command -v kustomize >/dev/null 2>&1; then
+  kustomize build deploy/ | kubectl apply -f -
+else
+  kubectl kustomize deploy/ | kubectl apply -f -
+fi
+
+bold "Restarting deployment"
+kubectl -n "$NAMESPACE" rollout restart deployment/kuberhealthy || true
+
+bold "Waiting for rollout"
+kubectl -n "$NAMESPACE" rollout status deployment/kuberhealthy --timeout=300s
+
+bold "Listing pods"
+kubectl -n "$NAMESPACE" get pods -o wide
+
+bold "Done"


### PR DESCRIPTION
## Summary
- add script to build and deploy Kuberhealthy to a local kind cluster using Podman
- wire new script into `deploy-k8s` Justfile recipe

## Testing
- `go test -short ./...` *(hangs)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e50a19648323a6b502f08473ad8c