### PR TITLE
Remove podSpec creationTimestamp cleanup

### DIFF
--- a/internal/webhook/convert.go
+++ b/internal/webhook/convert.go
@@ -73,25 +73,6 @@ func convertReview(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionRespon
 		return toError(fmt.Errorf("marshal v2: %w", err))
 	}
 
-	clean := map[string]any{}
-	if err := json.Unmarshal(newRaw, &clean); err != nil {
-		return toError(fmt.Errorf("unmarshal v2: %w", err))
-	}
-	if meta, ok := clean["spec"].(map[string]any); ok {
-		if podSpec, ok := meta["podSpec"].(map[string]any); ok {
-			if md, ok := podSpec["metadata"].(map[string]any); ok {
-				delete(md, "creationTimestamp")
-				if len(md) == 0 {
-					delete(podSpec, "metadata")
-				}
-			}
-		}
-	}
-	newRaw, err = json.Marshal(clean)
-	if err != nil {
-		return toError(fmt.Errorf("remarshal v2: %w", err))
-	}
-
 	ops, err := jsonpatch.CreatePatch(raw, newRaw)
 	if err != nil {
 		return toError(fmt.Errorf("create patch: %w", err))

--- a/internal/webhook/convert_test.go
+++ b/internal/webhook/convert_test.go
@@ -146,65 +146,6 @@ spec:
 	require.NoError(t, err)
 }
 
-func TestConvertRemovesPodSpecCreationTimestamp(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping in short mode")
-	}
-	legacy := `apiVersion: comcast.github.io/v1
-kind: KuberhealthyCheck
-metadata:
-  name: creation-time-test
-  namespace: kuberhealthy
-spec:
-  podSpec:
-    metadata:
-      creationTimestamp: null
-    containers:
-    - name: ct
-      image: test
-`
-	legacyJSON, err := yaml.YAMLToJSON([]byte(legacy))
-	require.NoError(t, err)
-
-	ar := admissionv1.AdmissionReview{
-		Request: &admissionv1.AdmissionRequest{
-			UID:    "789",
-			Object: runtimeRawExtension(legacyJSON),
-		},
-	}
-	body, err := json.Marshal(ar)
-	require.NoError(t, err)
-
-	req := httptest.NewRequest("POST", "/api/convert", bytes.NewReader(body))
-	w := httptest.NewRecorder()
-
-	Convert(w, req)
-
-	res := w.Result()
-	defer res.Body.Close()
-	require.Equal(t, http.StatusOK, res.StatusCode)
-
-	out := admissionv1.AdmissionReview{}
-	err = json.NewDecoder(res.Body).Decode(&out)
-	require.NoError(t, err)
-
-	patch, err := jsonpatch.DecodePatch(out.Response.Patch)
-	require.NoError(t, err)
-	patched, err := patch.Apply(legacyJSON)
-	require.NoError(t, err)
-
-	obj := map[string]any{}
-	err = json.Unmarshal(patched, &obj)
-	require.NoError(t, err)
-
-	spec, ok := obj["spec"].(map[string]any)
-	require.True(t, ok)
-	podSpec, ok := spec["podSpec"].(map[string]any)
-	require.True(t, ok)
-	_, ok = podSpec["metadata"]
-	require.False(t, ok)
-}
-
 func runtimeRawExtension(b []byte) runtime.RawExtension {
 	return runtime.RawExtension{Raw: b}
 }

--- a/pkg/api/kuberhealthycheck_types_test.go
+++ b/pkg/api/kuberhealthycheck_types_test.go
@@ -1,74 +1,11 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
-
-// TestGetCheckSetsCreationTimestamp ensures GetCheck populates metadata.CreationTimestamp when missing.
-func TestGetCheckSetsCreationTimestamp(t *testing.T) {
-	t.Parallel()
-
-	scheme := runtime.NewScheme()
-	require.NoError(t, AddToScheme(scheme))
-
-	check := &KuberhealthyCheck{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "default",
-		},
-	}
-
-	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(check).Build()
-	nn := types.NamespacedName{Name: "test", Namespace: "default"}
-
-	out, err := GetCheck(context.Background(), cl, nn)
-	require.NoError(t, err)
-	require.False(t, out.CreationTimestamp.IsZero(), "creation timestamp must be set")
-}
-
-// TestSpecDoesNotExposeCreationTimestamp ensures creationTimestamp is not serialized in pod metadata.
-func TestSpecDoesNotExposeCreationTimestamp(t *testing.T) {
-	t.Parallel()
-
-	check := &KuberhealthyCheck{
-		Spec: KuberhealthyCheckSpec{
-			PodSpec: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"foo": "bar"},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{{
-						Name:  "test",
-						Image: "busybox",
-					}},
-				},
-			},
-		},
-	}
-
-	raw, err := json.Marshal(check)
-	require.NoError(t, err)
-
-	var data map[string]any
-	require.NoError(t, json.Unmarshal(raw, &data))
-
-	spec := data["spec"].(map[string]any)
-	podSpec := spec["podSpec"].(map[string]any)
-	metadata := podSpec["metadata"].(map[string]any)
-	if v, found := metadata["creationTimestamp"]; found {
-		require.Nil(t, v, "creationTimestamp must be nil in spec.podSpec.metadata")
-	}
-
-}
 
 // TestSingleRunOnlyRoundTrip ensures singleRunOnly marshals and unmarshals correctly.
 func TestSingleRunOnlyRoundTrip(t *testing.T) {


### PR DESCRIPTION
## Summary
- stop scrubing `spec.podSpec.metadata.creationTimestamp` during webhook conversion
- drop tests asserting that `creationTimestamp` is stripped from pod specs

## Testing
- `go test -short ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b92d2a871c832392acadfda4fda539