### PR TITLE
Show khcheck run interval and error in wide output

### DIFF
--- a/deploy/base/kuberhealthycheck.yaml
+++ b/deploy/base/kuberhealthycheck.yaml
@@ -20,8 +20,11 @@ spec:
         - jsonPath: .status.ok
           name: OK
           type: boolean
-        - jsonPath: .status.currentUUID
-          name: UUID
+        - jsonPath: .spec.runInterval
+          name: RunInterval
+          type: string
+        - jsonPath: .status.errors[0]
+          name: Error
           type: string
         - jsonPath: .spec.timeout
           name: Timeout

--- a/pkg/api/kuberhealthycheck_types_test.go
+++ b/pkg/api/kuberhealthycheck_types_test.go
@@ -1,10 +1,16 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 // TestGetCheckSetsCreationTimestamp ensures GetCheck populates metadata.CreationTimestamp when missing.


### PR DESCRIPTION
## Summary
- replace blank UUID printer column with run interval in khcheck CRD
- surface first check error in wide output
- add missing imports to kuberhealthycheck type tests

## Testing
- `go test -short ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ba7fdacc208323b2eb080baafc5c81