### PR TITLE
Fix Prometheus metrics endpoint test

### DIFF
--- a/cmd/kuberhealthy/metrics_handler_test.go
+++ b/cmd/kuberhealthy/metrics_handler_test.go
@@ -56,7 +56,7 @@ func TestPrometheusMetricsEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed reading body: %v", err)
 	}
-	if !strings.Contains(string(body), "kuberhealthy_running") {
+	if !strings.Contains(string(body), "kuberhealthy_cluster_state") {
 		t.Fatalf("unexpected metrics body: %s", string(body))
 	}
 }


### PR DESCRIPTION
## Summary
- align TestPrometheusMetricsEndpoint with current metrics by checking for `kuberhealthy_cluster_state`

## Testing
- `go test -run TestPrometheusMetricsEndpoint ./cmd/kuberhealthy -v`
- `go test -short ./...`


------
https://chatgpt.com/codex/tasks/task_e_68be56dcab688323ab14ed1852d86a00