### PR TITLE
Add error message column to khcheck output

### DIFF
--- a/deploy/base/kuberhealthycheck.yaml
+++ b/deploy/base/kuberhealthycheck.yaml
@@ -24,7 +24,7 @@ spec:
           name: RunInterval
           type: string
         - jsonPath: .status.errors[0]
-          name: Error
+          name: ErrorMessage
           type: string
         - jsonPath: .spec.timeout
           name: Timeout


### PR DESCRIPTION
## Summary
- show first error message in khcheck custom resources via `ErrorMessage` printer column

## Testing
- `go test -short ./...`


------
https://chatgpt.com/codex/tasks/task_e_68be7e3232ac8323a76c8857dec1dd28