### PR TITLE
docs: add local development overview

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,9 @@
 
 ## Developer
 
+- For a quick local development setup, see [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
 - If you are making a large change, you should submit a proposal issue first so that you don't risk your feature being denied
-- Fork the Kuberhealthy/Kuberhealthy repository on github 
+- Fork the Kuberhealthy/Kuberhealthy repository on github
 - Clone your fork to your machine
 - Create a branch describing your change
 - Develop your feature and push changes to a branch in your fork

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,10 @@
+# Local Development
+
+Use these steps to work on Kuberhealthy locally.
+
+1. Build and format the code with `gopls` and `gofmt`. Editors that integrate with `gopls` usually run `go fmt` for you, or run `go fmt ./...` manually.
+2. Run `just kind` to start a [kind](https://kind.sigs.k8s.io/) cluster, build the Kuberhealthy image, and load it into the cluster.
+3. In another terminal, run `just browse` to port-forward to the cluster and view Kuberhealthy.
+4. Make changes to the code. When ready to test them, focus the `just kind` terminal and press **Enter** to rebuild the image and redeploy it.
+5. Apply checks to the cluster, such as `kubectl apply -f tests/khcheck-test.yaml`.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@
 - 📚 [Checks Registry](CHECKS_REGISTRY.md)
 - 📈 [Prometheus](PROMETHEUS.md)
 - 📄 [Status Page](STATUS_PAGE.md)
+- 🛠️ [Local Development](DEVELOPMENT.md)
 - 📊 [K8s KPIs with Kuberhealthy](K8s-KPIs-with-Kuberhealthy.md)
 - 📰 [Release Notes](RELEASE.md)
 - 🕰️ [Kuberhealthy 2.1.0 Release](Kuberhealthy-2.1.0-Release.md)


### PR DESCRIPTION
## Summary
- document a simple local development workflow using `just`
- link to new guide from docs and contributing guide

## Testing
- `go test ./...` *(fails: command produced no output and was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68c3c4cdca9c8323b001879c633fb8ba