### PR TITLE
Rename kuberhealthy check CRD to healthcheck

### DIFF
--- a/deploy/base/clusterrole.yaml
+++ b/deploy/base/clusterrole.yaml
@@ -20,9 +20,9 @@ rules:
   # Kuberhealthy CRDs (cluster-wide)
   - apiGroups: ["kuberhealthy.github.io"]
     resources:
-      - kuberhealthychecks
-      - kuberhealthychecks/finalizers
-      - kuberhealthychecks/status
+      - healthchecks
+      - healthchecks/finalizers
+      - healthchecks/status
     verbs: ["create","delete","get","list","patch","update","watch"]
 
   # Core v1 (cluster-wide)

--- a/deploy/base/healthcheckCrd.yaml
+++ b/deploy/base/healthcheckCrd.yaml
@@ -1,18 +1,18 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: kuberhealthychecks.kuberhealthy.github.io
+  name: healthchecks.kuberhealthy.github.io
 spec:
   group: kuberhealthy.github.io
   names:
-    kind: KuberhealthyCheck
-    listKind: KuberhealthyCheckList
-    plural: kuberhealthychecks
+    kind: healthcheck
+    listKind: healthcheckList
+    plural: healthchecks
     shortNames:
-      #- khc
-      #- khcheck
-      #- kuberhealthycheck
-    singular: kuberhealthycheck
+      #- hc
+      #- healthcheck
+      #- healthchecks
+    singular: healthcheck
   scope: Namespaced
   versions:
     - name: v2

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - namespace.yaml
   - deployment.yaml
   - service.yaml
-  - kuberhealthycheck.yaml
+  - healthcheckCrd.yaml
   - legacyKhcheckCrd.yaml
   - clusterrole.yaml
   - serviceaccount.yaml

--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - base/namespace.yaml
   - base/deployment.yaml
   - base/service.yaml
-  - base/kuberhealthycheck.yaml
+  - base/healthcheckCrd.yaml
   - base/legacyKhcheckCrd.yaml
   - base/clusterrole.yaml
   - base/serviceaccount.yaml


### PR DESCRIPTION
## Summary
- rename the Kuberhealthy check CRD to the healthcheck resource and update its metadata
- update base and top-level kustomizations to reference the renamed manifest
- align RBAC resources with the new healthcheck plural names

## Testing
- `/root/.local/share/mise/installs/go/1.24.3/bin/kustomize build deploy/base`


------
https://chatgpt.com/codex/tasks/task_e_68e301bfa01883239a6fda178719a46c