### PR TITLE
Update v2 manifests to use lowercase healthcheck kind

### DIFF
--- a/deploy/base/khcheck-example.yaml
+++ b/deploy/base/khcheck-example.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuberhealthy.github.io/v2
-kind: HealthCheck
+kind: healthcheck
 metadata:
   name: example-check
   namespace: kuberhealthy

--- a/docs/CHECK_CREATION.md
+++ b/docs/CHECK_CREATION.md
@@ -108,7 +108,7 @@ Here is a minimal `khcheck` resource to start hacking with:
 
 ```yaml
 apiVersion: kuberhealthy.github.io/v2
-kind: HealthCheck
+kind: healthcheck
 metadata:
   name: kh-test-check
 spec:

--- a/docs/runOnceChecks.md
+++ b/docs/runOnceChecks.md
@@ -8,7 +8,7 @@ Start with the same manifest structure as a recurring check and add `singleRunOn
 
 ```yaml
 apiVersion: kuberhealthy.github.io/v2
-kind: HealthCheck
+kind: healthcheck
 metadata:
   name: upgrade-smoke
   namespace: kuberhealthy

--- a/tests/khcheck-test.yaml
+++ b/tests/khcheck-test.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuberhealthy.github.io/v2
-kind: HealthCheck
+kind: healthcheck
 metadata:
   name: test
   namespace: kuberhealthy


### PR DESCRIPTION
## Summary
- update the base deployment example to declare the v2 resource as `kind: healthcheck`
- align the v2 test fixture and related documentation snippets with the lowercase kind

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e319347c1c83238de1042125a4448f