### PR TITLE
Trim namespace whitespace when reading service account namespace

### DIFF
--- a/cmd/kuberhealthy/util_test.go
+++ b/cmd/kuberhealthy/util_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestGetMyNamespaceTrimsWhitespace verifies that namespace values are trimmed before being returned.
+func TestGetMyNamespaceTrimsWhitespace(t *testing.T) {
+	t.Parallel()
+
+	// preserve the original namespace path so the test can restore it
+	originalPath := serviceAccountNamespacePath
+	t.Cleanup(func() {
+		serviceAccountNamespacePath = originalPath
+	})
+
+	// create a temporary namespace file containing trailing whitespace
+	tempDir := t.TempDir()
+	namespaceFile := filepath.Join(tempDir, "namespace")
+	err := os.WriteFile(namespaceFile, []byte("example-namespace\n"), 0o644)
+	if err != nil {
+		t.Fatalf("failed to write namespace file: %v", err)
+	}
+
+	// point the function under test at the temporary namespace file
+	serviceAccountNamespacePath = namespaceFile
+
+	// ensure the returned namespace is trimmed as expected
+	namespace := GetMyNamespace("default")
+	if namespace != "example-namespace" {
+		t.Fatalf("unexpected namespace value: %q", namespace)
+	}
+}
+
+// TestGetMyNamespaceFallsBackToDefault verifies that the default namespace is returned when the file is empty.
+func TestGetMyNamespaceFallsBackToDefault(t *testing.T) {
+	t.Parallel()
+
+	// preserve the original namespace file path to avoid leaking state between tests
+	originalPath := serviceAccountNamespacePath
+	t.Cleanup(func() {
+		serviceAccountNamespacePath = originalPath
+	})
+
+	// create an empty namespace file to simulate an unreadable value
+	tempDir := t.TempDir()
+	namespaceFile := filepath.Join(tempDir, "namespace")
+	err := os.WriteFile(namespaceFile, []byte(" \t\n"), 0o644)
+	if err != nil {
+		t.Fatalf("failed to write namespace file: %v", err)
+	}
+
+	// point GetMyNamespace at the empty namespace file and verify the default is returned
+	serviceAccountNamespacePath = namespaceFile
+	namespace := GetMyNamespace("fallback")
+	if namespace != "fallback" {
+		t.Fatalf("expected fallback namespace, got %q", namespace)
+	}
+}

--- a/cmd/kuberhealthy/util_test.go
+++ b/cmd/kuberhealthy/util_test.go
@@ -8,7 +8,6 @@ import (
 
 // TestGetMyNamespaceTrimsWhitespace verifies that namespace values are trimmed before being returned.
 func TestGetMyNamespaceTrimsWhitespace(t *testing.T) {
-	t.Parallel()
 
 	// preserve the original namespace path so the test can restore it
 	originalPath := serviceAccountNamespacePath
@@ -36,7 +35,6 @@ func TestGetMyNamespaceTrimsWhitespace(t *testing.T) {
 
 // TestGetMyNamespaceFallsBackToDefault verifies that the default namespace is returned when the file is empty.
 func TestGetMyNamespaceFallsBackToDefault(t *testing.T) {
-	t.Parallel()
 
 	// preserve the original namespace file path to avoid leaking state between tests
 	originalPath := serviceAccountNamespacePath


### PR DESCRIPTION
## Summary
- trim whitespace when reading the service account namespace file and allow the path to be overridden for tests
- add unit tests covering namespace trimming and the default fallback behavior

## Testing
- go test -count=1 ./...


------
https://chatgpt.com/codex/tasks/task_e_68e32391b8b883238e693f502c1ed967