### PR TITLE
Fix e2e script to use HealthCheck resources

### DIFF
--- a/tests/.ci/e2e.sh
+++ b/tests/.ci/e2e.sh
@@ -26,20 +26,22 @@ kubectl apply -k "$REPO_ROOT/deploy"
 kubectl -n "$NS" set image deployment/kuberhealthy kuberhealthy="$IMAGE_URL"
 
 # Wait for the CRD to be established before creating checks
-kubectl wait --for=condition=Established --timeout=60s crd/kuberhealthychecks.kuberhealthy.github.io
+kubectl wait --for=condition=Established --timeout=60s crd/healthchecks.kuberhealthy.github.io
 
 # Wait for kuberhealthy to be ready
 kubectl -n "$NS" rollout status deployment/kuberhealthy
 
 # Create a sample check for testing
-kubectl apply -f "$REPO_ROOT/tests/khcheck-test.yaml"
+kubectl apply -f "$REPO_ROOT/tests/healthcheck-test.yaml"
 
+# print_block prints a header and executes the provided command to make log output easier to parse.
 print_block() {
   printf '[%s] === %s ===\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$1"
   shift
   "$@"
 }
 
+# print_check_pod_logs iterates over check pods and prints their logs to aid in debugging failures.
 print_check_pod_logs() {
   check_pods=$(kubectl -n "$NS" get pods -o name | grep -v "$NAME" || true)
   for pod in $check_pods; do
@@ -49,14 +51,14 @@ print_check_pod_logs() {
 
 # repeatedly check for the test check to run successfully
 for i in {1..20}; do
-    checksOK=$(kubectl get -n "$NS" kuberhealthycheck -o jsonpath='{range .items[*]}{.status.ok}{"\n"}{end}' 2>/dev/null | grep -c true || true)
+    checksOK=$(kubectl get -n "$NS" healthcheck -o jsonpath='{range .items[*]}{.status.ok}{"\n"}{end}' 2>/dev/null | grep -c true || true)
     checksOK=${checksOK//[[:space:]]/}
     completedPods=$(kubectl -n "$NS" get pods --field-selector=status.phase=Succeeded -o name | wc -l | tr -d '[:space:]')
 
     if [ "$checksOK" -ge 1 ] && [ "$completedPods" -ge 1 ]; then
         echo "ALL KUBERHEALTHY CHECKS PASSED!!"
         print_block "Pod List" kubectl -n "$NS" get pods
-        print_block "KuberhealthyCheck List" kubectl -n "$NS" get kuberhealthycheck
+        print_block "HealthCheck List" kubectl -n "$NS" get healthcheck
         print_block "Kuberhealthy Pod Logs" kubectl -n "$NS" logs deployment/kuberhealthy
         print_check_pod_logs
         exit 0 # successful testing
@@ -65,7 +67,7 @@ for i in {1..20}; do
         echo "Checks Successful: $checksOK"
         echo "Completed check pods: $completedPods"
         print_block "Pod List" kubectl -n "$NS" get pods
-        print_block "KuberhealthyCheck List" kubectl -n "$NS" get kuberhealthycheck
+        print_block "HealthCheck List" kubectl -n "$NS" get healthcheck
         print_block "Kuberhealthy Pod Logs" kubectl -n "$NS" logs deployment/kuberhealthy
         print_check_pod_logs
         sleep 10


### PR DESCRIPTION
## Summary
- wait for the HealthCheck CRD before running the end-to-end test
- apply the HealthCheck sample manifest and query HealthCheck resources during the test
- document helper functions used in the e2e script for clarity

## Testing
- go test -short ./... *(fails: interrupted due to long runtime in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e4bc4bc0832392d55c5c3ce1ca3c