### PR TITLE
Fix legacy conversion test to use KuberhealthyCheck kind

### DIFF
--- a/internal/webhook/convert_test.go
+++ b/internal/webhook/convert_test.go
@@ -308,6 +308,14 @@ func TestConvertLegacyDeploymentManifest(t *testing.T) {
 	require.Equal(t, "comcast.github.io/v1", legacyMeta.APIVersion)
 	require.Equal(t, "HealthCheck", legacyMeta.Kind)
 
+	// rewrite the manifest to represent the original legacy kind so conversion must update both apiVersion and kind
+	legacyDoc := map[string]any{}
+	err = json.Unmarshal(legacyJSON, &legacyDoc)
+	require.NoError(t, err)
+	legacyDoc["kind"] = "KuberhealthyCheck"
+	legacyJSON, err = json.Marshal(legacyDoc)
+	require.NoError(t, err)
+
 	// build a minimal AdmissionReview payload targeting the legacy document
 	review := admissionv1.AdmissionReview{
 		Request: &admissionv1.AdmissionRequest{

--- a/tests/run-local-kind.sh
+++ b/tests/run-local-kind.sh
@@ -178,8 +178,8 @@ if [ "$READY_POD" = false ]; then
   exit 1
 fi
 
-echo "⏳ Deploying test khcheck..."
-kubectl --context="kind-${CLUSTER_NAME}" apply -n "$TARGET_NAMESPACE" -f tests/khcheck-test.yaml
+echo "⏳ Deploying test healthcheck..."
+kubectl --context="kind-${CLUSTER_NAME}" apply -n "$TARGET_NAMESPACE" -f tests/healthcheck-test.yaml
 
 start_logs
 start_port_forward


### PR DESCRIPTION
## Summary
- update the legacy conversion manifest test to rewrite the fixture kind to `KuberhealthyCheck` so the webhook patch must update both the group and kind

## Testing
- go test -short ./...
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e49cae2e208323b5d4058a93f69e7f