### PR TITLE
fix(deployment-check): bracket IPv6 ClusterIPs in HTTP URLs per RFC 3986

### DIFF
--- a/cmd/deployment-check/service_requester.go
+++ b/cmd/deployment-check/service_requester.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -40,9 +41,7 @@ func makeRequestToDeploymentCheckService(ctx context.Context, hostname string) c
 		}
 
 		// Prepend the hostname with a HTTP protocol.
-		if !strings.HasPrefix(hostname, "http://") {
-			hostname = "http://" + hostname
-		}
+		hostname = formatURL(hostname)
 
 		// Try to make requests to the hostname endpoint and wait for a result.
 		select {
@@ -167,4 +166,17 @@ func getRequestBackoff(hostname string) chan RequestResult {
 	}()
 
 	return requestResultChan
+}
+
+// formatURL prepends the hostname with an HTTP scheme. IPv6 addresses are
+// wrapped in brackets per RFC 3986 §3.2.2 so that Go's net/url can parse
+// them correctly.
+func formatURL(hostname string) string {
+	if strings.HasPrefix(hostname, "http://") {
+		return hostname
+	}
+	if ip := net.ParseIP(hostname); ip != nil && ip.To4() == nil {
+		return "http://[" + hostname + "]"
+	}
+	return "http://" + hostname
 }

--- a/cmd/deployment-check/service_requester_test.go
+++ b/cmd/deployment-check/service_requester_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestFormatURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "IPv4 address",
+			input:    "10.96.42.5",
+			expected: "http://10.96.42.5",
+		},
+		{
+			name:     "IPv6 address",
+			input:    "fd00:4:32::6c47",
+			expected: "http://[fd00:4:32::6c47]",
+		},
+		{
+			name:     "IPv6 loopback",
+			input:    "::1",
+			expected: "http://[::1]",
+		},
+		{
+			name:     "IPv6 full address",
+			input:    "2001:db8:85a3:0000:0000:8a2e:0370:7334",
+			expected: "http://[2001:db8:85a3:0000:0000:8a2e:0370:7334]",
+		},
+		{
+			name:     "hostname",
+			input:    "my-service.default.svc.cluster.local",
+			expected: "http://my-service.default.svc.cluster.local",
+		},
+		{
+			name:     "already has scheme",
+			input:    "http://10.96.42.5",
+			expected: "http://10.96.42.5",
+		},
+		{
+			name:     "IPv4 loopback",
+			input:    "127.0.0.1",
+			expected: "http://127.0.0.1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := formatURL(tc.input)
+			if result != tc.expected {
+				t.Errorf("formatURL(%q) = %q, want %q", tc.input, result, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- The deployment-check service endpoint HTTP check constructs URLs by prepending `http://` to the raw ClusterIP address. On IPv6-only (and dual-stack) clusters, this produces invalid URLs like `http://fd00::1` instead of `http://[fd00::1]`, causing `http.Get()` to fail and the backoff loop to always time out.
- Extracted URL formatting into a testable `formatURL()` helper that uses `net.ParseIP().To4()` to detect IPv6 addresses and wraps them in brackets per [RFC 3986 §3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2).
- Added `TestFormatURL` with 7 test cases covering IPv4, IPv6, hostnames, and pre-formatted URLs.

## Bug details

**File:** `cmd/deployment-check/service_requester.go` — `makeRequestToDeploymentCheckService()`

The call chain:
1. `run_check.go`: `ipAddress := getServiceClusterIP(ctx)` — returns raw IPv6 string (e.g. `fd00:4:32::6c47`)
2. `run_check.go`: `makeRequestToDeploymentCheckService(ctx, ipAddress)`
3. `service_requester.go`: `hostname = "http://" + hostname` → `http://fd00:4:32::6c47` (invalid URL)

**Observed on:** IPv6-only Kubernetes cluster (3 control plane + 3 worker nodes, Cilium CNI)

```
level=info msg="Deployment is reporting Available with True."
level=info msg="2 deployment pods are ready and available."
level=info msg="Found service cluster IP address: fd00:4:32::6c47"
level=info msg="Looking for a response from the endpoint."
level=info msg="Retrying in 5 seconds."
...
level=error msg="Backoff loop for a 200 response took too long and timed out."
```

## Test plan

- [x] `go build ./cmd/deployment-check/` compiles cleanly
- [x] `go test ./cmd/deployment-check/ -v` — all 4 tests pass (3 existing + 1 new)
- [ ] Deploy on IPv6-only cluster and verify deployment check passes end-to-end

I'm happy to help with any further changes needed. I run an IPv6-only k8s cluster and can test thoroughly.