### PR TITLE
Add Kubernetes health badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2822/badge)](https://bestpractices.coreinfrastructure.org/projects/2822)
 [![Twitter Follow](https://img.shields.io/twitter/follow/kuberhealthy.svg?style=social)](https://twitter.com/kuberhealthy)  
 [![Join Slack](https://img.shields.io/badge/slack-kubernetes/kuberhealthy-teal.svg?logo=slack)](https://kubernetes.slack.com/messages/CB9G7HWTE)
+[![Kubernetes Health](https://img.releaserun.com/badge/health/kubernetes.svg)](https://releaserun.com/badges/kubernetes/)
 
 ## Table of Contents
 


### PR DESCRIPTION
## Add Kubernetes Health Badge

Adds a [ReleaseRun](https://releaserun.com) Kubernetes health badge that shows the current health status of the Kubernetes runtime. It updates automatically based on:

- **Version freshness** (how current the latest stable release is)
- **Security status** (known CVEs affecting the latest version)
- **End-of-life timeline** (how much support time remains)

**Badge preview**: ![Kubernetes Health](https://img.releaserun.com/badge/health/kubernetes.svg)

Seemed fitting for a project literally named "Kuberhealthy" to show the health of the platform it monitors. The badge is free, requires no API key, and links to a detailed breakdown page.

Happy to adjust placement if you'd prefer it somewhere else in the README.