### PR TITLE
Fix error propagation in deployment check

### DIFF
--- a/cmd/deployment-check/service_requester.go
+++ b/cmd/deployment-check/service_requester.go
@@ -71,18 +71,24 @@ func makeRequestToDeploymentCheckService(ctx context.Context, hostname string) c
 			log.Infoln("Got a result from", http.MethodGet, "request backoff:", result.Response.Status)
 			requestChan <- nil
 		case <-timeoutChan:
-			log.Errorln("Backoff loop for a 200 response took too long and timed out.")
-			err := cleanUp(ctx)
-			if err != nil {
-				err = fmt.Errorf("failed to clean up properly: %w", err)
+			err := errors.New("backoff loop for a 200 response took too long and timed out")
+			log.Errorln(err.Error())
+
+			cleanUpErr := cleanUp(ctx)
+			if cleanUpErr != nil {
+				err = fmt.Errorf("%w (cleanup: %v)", err, cleanUpErr)
 			}
+
 			requestChan <- err
 		case <-ctx.Done():
-			log.Errorln("Context expired while waiting for a", http.StatusOK, "from "+hostname+".")
-			err := cleanUp(ctx)
-			if err != nil {
-				err = fmt.Errorf("failed to clean up properly: %w", err)
+			err := fmt.Errorf("context expired while waiting for a %d from %s", http.StatusOK, hostname)
+			log.Errorln(err.Error())
+
+			cleanUpErr := cleanUp(ctx)
+			if cleanUpErr != nil {
+				err = fmt.Errorf("%w (cleanup: %v)", err, cleanUpErr)
 			}
+
 			requestChan <- err
 		}
 
@@ -144,10 +150,10 @@ func getRequestBackoff(hostname string) chan RequestResult {
 			if resp != nil {
 				log.Debugln("Got a", resp.StatusCode)
 				if resp.StatusCode == 502 {
-                                    // When running with istio we get a 502 with err being nil so retry terminates
-                                    // Handle this scenario by resetting error to not nil
-                                    err = errors.New("")
-                                }
+					// When running with istio we get a 502 with err being nil so retry terminates
+					// Handle this scenario by resetting error to not nil
+					err = errors.New("")
+				}
 				closeErr := resp.Body.Close()
 				if closeErr != nil {
 					log.Debugln("Failed to close response body:", closeErr.Error())


### PR DESCRIPTION
PR fixes error propagation issues in the deployment check where timeout and context cancellation were not reported back to the caller. 

In [service_requester.go](https://github.com/kuberhealthy/kuberhealthy/blob/master/cmd/deployment-check/service_requester.go#L73-L79) the `case <- timeoutChan` and `case <- ctx.Done()` branches do not return the actual errors. 

The caller: [run_check.go](https://github.com/kuberhealthy/kuberhealthy/blob/master/cmd/deployment-check/run_check.go#L141) only reacts to non-nil errors, so timeouts and context cancellation are ignored and main flow continues as nothing happened.