### PR TITLE
Update deployment-check examples to v0.1.1

### DIFF
--- a/docs/healthchecks/DEPLOYMENT_CHECK.yaml
+++ b/docs/healthchecks/DEPLOYMENT_CHECK.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: deployment
-          image: kuberhealthy/deployment-check:v0.1.0
+          image: kuberhealthy/deployment-check:v0.1.1
           imagePullPolicy: IfNotPresent
           env:
             - name: CHECK_DEPLOYMENT_REPLICAS

--- a/tests/khcheck-test.yaml
+++ b/tests/khcheck-test.yaml
@@ -10,7 +10,7 @@ spec:
   podSpec:
     containers:
       - name: deployment
-        image: kuberhealthy/deployment-check:v1.9.1
+        image: kuberhealthy/deployment-check:v0.1.1
         imagePullPolicy: IfNotPresent
         env:
           - name: CHECK_DEPLOYMENT_REPLICAS


### PR DESCRIPTION
This syncs Kuberhealthy's checked-in deployment-check examples to the `v0.1.1` image tag.

- update the v3 example manifest to `kuberhealthy/deployment-check:v0.1.1`
- update the checked-in test manifest to the same image tag

Merge this after the `deployment-check` `v0.1.1` release is published so the examples match an available image.