### PR TITLE
fix: prevent duplicate checker pod creation on startup

### DIFF
--- a/internal/kuberhealthy/kuberhealthy.go
+++ b/internal/kuberhealthy/kuberhealthy.go
@@ -81,6 +81,9 @@ type Kuberhealthy struct {
 
 	metricsMu       sync.Mutex
 	metricsSnapshot controllerMetricsSnapshot
+
+	checkStartMu sync.Mutex                    // guards checkStarting map access
+	checkStarting map[types.NamespacedName]bool // tracks checks currently in StartCheck to prevent duplicate pod creation
 }
 
 // New creates a new Kuberhealthy instance, event recorder, and optional shutdown notifier.
@@ -106,6 +109,7 @@ func New(ctx context.Context, checkClient client.Client, doneChan ...chan struct
 		ErrorPodRetentionTime: 36 * time.Hour,
 		MaxCheckPodAge:        0,
 		metricsSnapshot:       newControllerMetricsSnapshot(),
+		checkStarting:         make(map[types.NamespacedName]bool),
 	}
 }
 
@@ -806,6 +810,26 @@ func (kh *Kuberhealthy) IsReportAllowed(check *khapi.HealthCheck, uuid string) b
 	return time.Since(start) < timeout
 }
 
+// tryStartCheck atomically marks a check as starting. Returns false if the
+// check is already being started by another goroutine.
+func (kh *Kuberhealthy) tryStartCheck(name types.NamespacedName) bool {
+	kh.checkStartMu.Lock()
+	defer kh.checkStartMu.Unlock()
+	if kh.checkStarting[name] {
+		return false
+	}
+	kh.checkStarting[name] = true
+	return true
+}
+
+// finishStartCheck removes the in-progress marker so the check can be started
+// again on its next scheduled run.
+func (kh *Kuberhealthy) finishStartCheck(name types.NamespacedName) {
+	kh.checkStartMu.Lock()
+	defer kh.checkStartMu.Unlock()
+	delete(kh.checkStarting, name)
+}
+
 // StartCheck begins tracking and managing a HealthCheck whenever the controller observes a new resource.
 func (kh *Kuberhealthy) StartCheck(healthCheck *khapi.HealthCheck) error {
 	log.Infoln("Starting healthcheck", healthCheck.GetNamespace(), healthCheck.GetName())
@@ -821,9 +845,16 @@ func (kh *Kuberhealthy) StartCheck(healthCheck *khapi.HealthCheck) error {
 		Name:      healthCheck.GetName(),
 	}
 
+	// prevent concurrent StartCheck calls for the same check from the
+	// informer and the scheduler loop racing at startup
+	if !kh.tryStartCheck(checkName) {
+		return fmt.Errorf("check %s is already being started", checkName)
+	}
+
 	// use CurrentUUID to signal the check is running
 	err := kh.setFreshUUID(checkName)
 	if err != nil {
+		kh.finishStartCheck(checkName)
 		return fmt.Errorf("unable to set running UUID: %w", err)
 	}
 
@@ -1443,6 +1474,7 @@ func (k *Kuberhealthy) setCheckExecutionError(checkName types.NamespacedName, ch
 // clearUUID clears the UUID assigned to the check, which indicates
 // that it is not running.
 func (k *Kuberhealthy) clearUUID(checkName types.NamespacedName) error {
+	defer k.finishStartCheck(checkName)
 	ctx := k.controllerContext()
 
 	// get the check as it is right now

--- a/internal/kuberhealthy/kuberhealthy_test.go
+++ b/internal/kuberhealthy/kuberhealthy_test.go
@@ -245,7 +245,12 @@ func TestStartCheckPodCreationFailureClearsRunState(t *testing.T) {
 	client := &toggleCreateClient{Client: baseClient, failCreates: true}
 	kh := New(context.Background(), client)
 	kh.SetReportingURL("http://example.com")
-	startLeaderTasksForTest(t, kh)
+	// Set leader state directly without starting background loops to avoid
+	// the scheduler racing for tryStartCheck.
+	kh.leaderMu.Lock()
+	kh.leaderRunning = true
+	kh.leaderContext = context.Background()
+	kh.leaderMu.Unlock()
 
 	err := kh.StartCheck(check)
 	require.Error(t, err)
@@ -266,6 +271,84 @@ func TestStartCheckPodCreationFailureClearsRunState(t *testing.T) {
 	postRun, getErr := khapi.GetCheck(context.Background(), client, namespacedName)
 	require.NoError(t, getErr)
 	require.NotEmpty(t, postRun.CurrentUUID())
+}
+
+// TestConcurrentStartCheckCreatesOnlyOnePod verifies that the tryStartCheck guard prevents
+// duplicate pod creation when StartCheck is called multiple times for the same check.
+func TestConcurrentStartCheckCreatesOnlyOnePod(t *testing.T) {
+	t.Parallel()
+
+	// Verify tryStartCheck/finishStartCheck lock behavior directly.
+	scheme := runtime.NewScheme()
+	require.NoError(t, khapi.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	check := &khapi.HealthCheck{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "concurrent-check",
+			Namespace: "default",
+		},
+		Spec: khapi.HealthCheckSpec{
+			PodSpec: khapi.CheckPodSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "test",
+						Image: "busybox",
+					}},
+				},
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(check).WithStatusSubresource(check).Build()
+	kh := New(context.Background(), cl)
+	kh.SetReportingURL("http://example.com")
+
+	checkName := types.NamespacedName{Name: check.Name, Namespace: check.Namespace}
+
+	// First tryStartCheck should succeed.
+	require.True(t, kh.tryStartCheck(checkName), "first tryStartCheck should succeed")
+
+	// Concurrent attempts for the same check should be rejected.
+	const goroutines = 10
+	results := make(chan bool, goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			results <- kh.tryStartCheck(checkName)
+		}()
+	}
+	for i := 0; i < goroutines; i++ {
+		require.False(t, <-results, "concurrent tryStartCheck should be rejected")
+	}
+
+	// Release the lock.
+	kh.finishStartCheck(checkName)
+
+	// After release, tryStartCheck should succeed again.
+	require.True(t, kh.tryStartCheck(checkName), "tryStartCheck after release should succeed")
+	kh.finishStartCheck(checkName)
+
+	// Integration: start leader tasks only now so the scheduler doesn't race with our manual calls above.
+	startLeaderTasksForTest(t, kh)
+
+	// First StartCheck succeeds.
+	require.NoError(t, kh.StartCheck(check))
+
+	pods := &corev1.PodList{}
+	require.NoError(t, cl.List(context.Background(), pods))
+	require.Len(t, pods.Items, 1, "first StartCheck should create one pod")
+
+	// Second call should fail because the check is still marked as starting.
+	freshCheck, err := khapi.GetCheck(context.Background(), cl, checkName)
+	require.NoError(t, err)
+	err = kh.StartCheck(freshCheck)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "already being started")
+
+	// Still only one pod.
+	pods = &corev1.PodList{}
+	require.NoError(t, cl.List(context.Background(), pods))
+	require.Len(t, pods.Items, 1, "second StartCheck should not create another pod")
 }
 
 // toggleCreateClient wraps a controller-runtime client and injects pod creation failures when requested.
@@ -315,7 +398,13 @@ func TestScheduleStartsCheck(t *testing.T) {
 
 	cl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(check).WithStatusSubresource(check).Build()
 	kh := New(context.Background(), cl)
-	startLeaderTasksForTest(t, kh)
+	// Set leader state directly without starting background loops, since this
+	// test calls scheduleChecks manually and the background scheduler would
+	// race for tryStartCheck.
+	kh.leaderMu.Lock()
+	kh.leaderRunning = true
+	kh.leaderContext = context.Background()
+	kh.leaderMu.Unlock()
 
 	delay := kh.scheduleChecks(context.Background())
 	require.Equal(t, minimumScheduleInterval, delay)


### PR DESCRIPTION
Add a per-check mutex guard in StartCheck to prevent the informer handleAdd and the scheduler loop from racing and creating two pods for the same health check simultaneously.

A tryStartCheck/finishStartCheck pattern ensures only one goroutine can enter StartCheck for a given HealthCheck at a time.

Fixes #1499