### PR TITLE
fix: release check start guard on report

### DIFF
--- a/cmd/kuberhealthy/webserver.go
+++ b/cmd/kuberhealthy/webserver.go
@@ -1125,5 +1125,9 @@ func setCheckStatus(c client.Client, checkName string, checkNamespace string, in
 		return fmt.Errorf("failed to update healthcheck status: %w", err)
 	}
 
+	if incoming != nil && incoming.CurrentUUID == "" && Globals.kh != nil {
+		Globals.kh.ReleaseCheckStart(nn)
+	}
+
 	return nil
 }

--- a/internal/kuberhealthy/kuberhealthy.go
+++ b/internal/kuberhealthy/kuberhealthy.go
@@ -81,6 +81,9 @@ type Kuberhealthy struct {
 
 	metricsMu       sync.Mutex
 	metricsSnapshot controllerMetricsSnapshot
+
+	checkStartMu  sync.Mutex
+	checkStarting map[types.NamespacedName]bool
 }
 
 // New creates a new Kuberhealthy instance, event recorder, and optional shutdown notifier.
@@ -106,6 +109,7 @@ func New(ctx context.Context, checkClient client.Client, doneChan ...chan struct
 		ErrorPodRetentionTime: 36 * time.Hour,
 		MaxCheckPodAge:        0,
 		metricsSnapshot:       newControllerMetricsSnapshot(),
+		checkStarting:         make(map[types.NamespacedName]bool),
 	}
 }
 
@@ -806,6 +810,32 @@ func (kh *Kuberhealthy) IsReportAllowed(check *khapi.HealthCheck, uuid string) b
 	return time.Since(start) < timeout
 }
 
+// tryStartCheck marks a check as starting and rejects concurrent attempts.
+func (kh *Kuberhealthy) tryStartCheck(checkName types.NamespacedName) bool {
+	kh.checkStartMu.Lock()
+	defer kh.checkStartMu.Unlock()
+
+	if kh.checkStarting[checkName] {
+		return false
+	}
+
+	kh.checkStarting[checkName] = true
+	return true
+}
+
+// finishStartCheck clears the in-memory start guard for a check.
+func (kh *Kuberhealthy) finishStartCheck(checkName types.NamespacedName) {
+	kh.checkStartMu.Lock()
+	defer kh.checkStartMu.Unlock()
+
+	delete(kh.checkStarting, checkName)
+}
+
+// ReleaseCheckStart clears the in-memory start guard after a run completes.
+func (kh *Kuberhealthy) ReleaseCheckStart(checkName types.NamespacedName) {
+	kh.finishStartCheck(checkName)
+}
+
 // StartCheck begins tracking and managing a HealthCheck whenever the controller observes a new resource.
 func (kh *Kuberhealthy) StartCheck(healthCheck *khapi.HealthCheck) error {
 	log.Infoln("Starting healthcheck", healthCheck.GetNamespace(), healthCheck.GetName())
@@ -821,9 +851,14 @@ func (kh *Kuberhealthy) StartCheck(healthCheck *khapi.HealthCheck) error {
 		Name:      healthCheck.GetName(),
 	}
 
+	if !kh.tryStartCheck(checkName) {
+		return fmt.Errorf("check %s is already being started", checkName)
+	}
+
 	// use CurrentUUID to signal the check is running
 	err := kh.setFreshUUID(checkName)
 	if err != nil {
+		kh.finishStartCheck(checkName)
 		return fmt.Errorf("unable to set running UUID: %w", err)
 	}
 
@@ -1443,6 +1478,8 @@ func (k *Kuberhealthy) setCheckExecutionError(checkName types.NamespacedName, ch
 // clearUUID clears the UUID assigned to the check, which indicates
 // that it is not running.
 func (k *Kuberhealthy) clearUUID(checkName types.NamespacedName) error {
+	defer k.finishStartCheck(checkName)
+
 	ctx := k.controllerContext()
 
 	// get the check as it is right now

--- a/internal/kuberhealthy/kuberhealthy_test.go
+++ b/internal/kuberhealthy/kuberhealthy_test.go
@@ -206,7 +206,10 @@ func TestStartCheckCreatesPodInCheckNamespace(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(check).WithStatusSubresource(check).Build()
 	kh := New(context.Background(), cl)
 	kh.SetReportingURL("http://example.com")
-	startLeaderTasksForTest(t, kh)
+	kh.leaderMu.Lock()
+	kh.leaderRunning = true
+	kh.leaderContext = context.Background()
+	kh.leaderMu.Unlock()
 
 	require.NoError(t, kh.StartCheck(check))
 
@@ -245,7 +248,10 @@ func TestStartCheckPodCreationFailureClearsRunState(t *testing.T) {
 	client := &toggleCreateClient{Client: baseClient, failCreates: true}
 	kh := New(context.Background(), client)
 	kh.SetReportingURL("http://example.com")
-	startLeaderTasksForTest(t, kh)
+	kh.leaderMu.Lock()
+	kh.leaderRunning = true
+	kh.leaderContext = context.Background()
+	kh.leaderMu.Unlock()
 
 	err := kh.StartCheck(check)
 	require.Error(t, err)
@@ -266,6 +272,59 @@ func TestStartCheckPodCreationFailureClearsRunState(t *testing.T) {
 	postRun, getErr := khapi.GetCheck(context.Background(), client, namespacedName)
 	require.NoError(t, getErr)
 	require.NotEmpty(t, postRun.CurrentUUID())
+}
+
+// TestStartCheckCanRunAgainAfterRelease verifies the start guard is released when a run completes.
+func TestStartCheckCanRunAgainAfterRelease(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, khapi.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	check := &khapi.HealthCheck{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "release-check",
+			Namespace: "default",
+		},
+		Spec: khapi.HealthCheckSpec{
+			PodSpec: khapi.CheckPodSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "test",
+						Image: "busybox",
+					}},
+				},
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(check).WithStatusSubresource(check).Build()
+	kh := New(context.Background(), cl)
+	kh.SetReportingURL("http://example.com")
+	kh.leaderMu.Lock()
+	kh.leaderRunning = true
+	kh.leaderContext = context.Background()
+	kh.leaderMu.Unlock()
+
+	namespacedName := types.NamespacedName{Namespace: check.Namespace, Name: check.Name}
+
+	require.NoError(t, kh.StartCheck(check))
+
+	reported, err := kh.readCheck(namespacedName)
+	require.NoError(t, err)
+	reported.Status.CurrentUUID = ""
+	require.NoError(t, khapi.UpdateCheck(context.Background(), cl, reported))
+
+	kh.ReleaseCheckStart(namespacedName)
+
+	refreshed, err := kh.readCheck(namespacedName)
+	require.NoError(t, err)
+	require.NoError(t, kh.StartCheck(refreshed))
+
+	pods := &corev1.PodList{}
+	require.NoError(t, cl.List(context.Background(), pods))
+	require.Len(t, pods.Items, 2)
 }
 
 // toggleCreateClient wraps a controller-runtime client and injects pod creation failures when requested.


### PR DESCRIPTION
Fix the new `StartCheck` guard so a successful check report does not leave the check permanently marked as "starting".

## What changed
- add a per-check in-memory start guard in `StartCheck`
- release that guard when `/check` successfully clears `status.currentUUID`
- keep the existing release on controller-side `clearUUID`
- tighten the direct `StartCheck` tests so they do not race the background scheduler
- add a lifecycle test that verifies a check can run again after completion

## Why
The bootstrap race fix in #1500 is directionally correct, but it leaves a gap on the normal success path. Successful reports clear `status.currentUUID` through the web handler path instead of `clearUUID()`. Without releasing the in-memory guard there as well, the first successful run can block all future runs for that check.

## Impact
- prevents duplicate startup pod creation for the same check
- preserves normal re-scheduling after a successful report
- keeps the fix scoped to the existing controller/report lifecycle

## Validation
- `go test -count=1 -timeout=60s ./internal/kuberhealthy -run 'TestStartCheckCanRunAgainAfterRelease|TestStartCheckPodCreationFailureClearsRunState|TestScheduleStartsCheck|TestStartCheckCreatesPodInCheckNamespace'`
- `go test -count=1 -timeout=60s ./cmd/kuberhealthy -run 'TestCheckReportHandler|TestStoreCheckStateRetriesOnConflict'`