### PR TITLE
Fix/release start block if check reported to replica

### DIFF
--- a/internal/kuberhealthy/kuberhealthy.go
+++ b/internal/kuberhealthy/kuberhealthy.go
@@ -1107,8 +1107,8 @@ func (kh *Kuberhealthy) UpdateCheck(oldKHCheck *khapi.HealthCheck, newKHCheck *k
 		"namespace": newKHCheck.Namespace,
 		"name":      newKHCheck.Name,
 		"pod":       newKHCheck.Name,
-	}).Info("KHCheck resoruce updated")
-	// TODO - do we do anything on updates to reload the latest check? How do we prevent locking into an infinite udpate window with the controller?
+	}).Info("KHCheck resource updated")
+	// TODO - do we do anything on updates to reload the latest check? How do we prevent locking into an infinite update window with the controller?
 
 	// // stop the check
 	// err := kh.StopCheck(oldKHCheck)

--- a/internal/kuberhealthy/kuberhealthy.go
+++ b/internal/kuberhealthy/kuberhealthy.go
@@ -542,7 +542,8 @@ func (kh *Kuberhealthy) handleCreate(ctx context.Context, khc *khapi.HealthCheck
 	}
 }
 
-// handleUpdate reconciles finalizers and restarts checks when their spec changes.
+// handleUpdate reconciles finalizers, restarts checks when their spec changes,
+// and clears in-memory start flags when UUID is cleared (across instances).
 func (kh *Kuberhealthy) handleUpdate(ctx context.Context, oldCheck *khapi.HealthCheck, newCheck *khapi.HealthCheck) {
 	if !newCheck.GetDeletionTimestamp().IsZero() {
 		if kh.hasFinalizer(newCheck) {
@@ -570,6 +571,21 @@ func (kh *Kuberhealthy) handleUpdate(ctx context.Context, oldCheck *khapi.Health
 		"namespace": newCheck.Namespace,
 		"name":      newCheck.Name,
 	}).Info("modified checker pod")
+
+	// If the UUID was cleared (either by this instance or another), release the in-memory start flag.
+	// This ensures the check can be restarted on the next scheduler cycle, even if the pod report
+	// was handled by a different instance (replica) and we're the leader.
+	if oldCheck.CurrentUUID() != "" && newCheck.CurrentUUID() == "" {
+		checkName := types.NamespacedName{
+			Namespace: newCheck.Namespace,
+			Name:      newCheck.Name,
+		}
+		log.WithFields(log.Fields{
+			"namespace": newCheck.Namespace,
+			"name":      newCheck.Name,
+		}).Debug("releasing the in-memory start flag")
+		kh.finishStartCheck(checkName)
+	}
 
 	err := kh.UpdateCheck(oldCheck, newCheck)
 	if err != nil {

--- a/internal/kuberhealthy/kuberhealthy_test.go
+++ b/internal/kuberhealthy/kuberhealthy_test.go
@@ -387,6 +387,64 @@ func TestStartCheckRefreshFailureReleasesStartGuard(t *testing.T) {
 	require.Len(t, pods.Items, 2)
 }
 
+// TestHandleUpdateReleasesStartGuardWhenCurrentUUIDCleared verifies that the controller releases its
+// in-memory start guard when it observes another replica clearing CurrentUUID.
+func TestHandleUpdateReleasesStartGuardWhenCurrentUUIDCleared(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, khapi.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	check := &khapi.HealthCheck{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "uuid-cleared-check",
+			Namespace: "default",
+		},
+		Spec: khapi.HealthCheckSpec{
+			PodSpec: khapi.CheckPodSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "test",
+						Image: "busybox",
+					}},
+				},
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(check).WithStatusSubresource(check).Build()
+	kh := New(context.Background(), cl)
+	kh.SetReportingURL("http://example.com")
+	kh.leaderMu.Lock()
+	kh.leaderRunning = true
+	kh.leaderContext = context.Background()
+	kh.leaderMu.Unlock()
+
+	namespacedName := types.NamespacedName{Namespace: check.Namespace, Name: check.Name}
+
+	require.NoError(t, kh.StartCheck(check))
+
+	oldCheck, err := kh.readCheck(namespacedName)
+	require.NoError(t, err)
+	require.NotEmpty(t, oldCheck.CurrentUUID())
+
+	completedCheck := oldCheck.DeepCopy()
+	completedCheck.Status.CurrentUUID = ""
+	require.NoError(t, khapi.UpdateCheck(context.Background(), cl, completedCheck))
+
+	kh.handleUpdate(context.Background(), oldCheck, completedCheck)
+
+	refreshed, err := kh.readCheck(namespacedName)
+	require.NoError(t, err)
+	require.Empty(t, refreshed.CurrentUUID())
+	require.NoError(t, kh.StartCheck(refreshed))
+
+	pods := &corev1.PodList{}
+	require.NoError(t, cl.List(context.Background(), pods))
+	require.Len(t, pods.Items, 2)
+}
+
 // toggleCreateClient wraps a controller-runtime client and injects pod creation failures when requested.
 type toggleCreateClient struct {
 	client.Client


### PR DESCRIPTION
Hi @integrii,

Great work on the huge refactor!

I started using v3 yesterday and noticed that, after a few scheduled runs, most of my checks no longer started. I cloned the Helm files and kept `replicas: 2`.

After analyzing which checks start and which do not start after restarting the Kuberhealthy deployment, I found that the issue is caused by the in-memory start guard not being released on the leader pod if the check response is received by a non-leader. Without releasing it, it keeps failing with `check {check-name} is already being started`.

I tested this change in my cluster, and now the lock is successfully released and all checks start as expected.

```log
time="2026-06-10T11:07:02Z" level=info msg="modified checker pod" name=http-internal namespace=kuberhealthy
time="2026-06-10T11:07:02Z" level=debug msg="releasing the in-memory start flag" name=http-internal namespace=kuberhealthy
time="2026-06-10T11:07:02Z" level=info msg="KHCheck resource updated" name=http-internal namespace=kuberhealthy pod=http-internal
```

But maybe you have a better spot where this could fit?

Thanks again for your work on this!

Best regards  
Oliver

### Off-topic: A couple more things I noticed:

#### Go package versions

When looking at the Go package versions, a `3.0.1` version exists that is actually older than `3.0.0`. See: https://pkg.go.dev/github.com/kuberhealthy/kuberhealthy/v3/pkg/api?tab=versions  

#### Rewriting of `runInterval` and `timeout` in CRD

 I am using two Helm deployments: one for Kuberhealthy (deployed first), and another for my checks and a custom 
orchestrator, which reads the CRDs to report and transform results to a different backend. Kuberhealthy seems to rewrite the `runInterval` and `timeout` values from, for example, `5m` to `5m0s`.  
  Because of this, I had to adjust the values in my second Helm deployment to match the updated CRD syntax. Otherwise, I would get:

```txt
conflict occurred while applying object kuberhealthy/dns-status-internal kuberhealthy.github.io/v2, Kind=HealthCheck: Apply failed with 2 conflicts: conflicts with "kuberhealthy" using kuberhealthy.github.io/v2:
- .spec.runInterval
- .spec.timeout
```

and many more. After adjusting the values to include `0s`, the Helm upgrades worked without issues.

#### edited this PR

originally i have done these changes aswell, but i have skipped them for now, also the scope was too big.

I also updated the Go version, dependencies, and the GitHub Actions to match the newer Go version and due to the following warning

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

If that’s too many changes, I’m happy to revert the build-related updates. I can only test the github action changes in this PR.